### PR TITLE
Fixes #38 - System.Runtime reference on .NET 4.5

### DIFF
--- a/samples/Sample/project.json
+++ b/samples/Sample/project.json
@@ -5,15 +5,12 @@
   },
   "dependencies": {
     "Serilog.Extensions.Logging": { "target": "project" },
-    "Serilog.Sinks.Literate": "2.0.0-rc-25"
+    "Serilog.Sinks.Literate": "2.0.0-rc-25",
+    "Microsoft.Extensions.Logging": "1.0.0-rc2-final"
   },
 
   "frameworks": {
-    "net4.6": {
-      "frameworkAssemblies": {
-        "System.Runtime": ""
-      }
-    },
+    "net4.6": {},
     "netcoreapp1.0": {
       "define": [ "ASYNCLOCAL" ],
       "dependencies": {

--- a/src/Serilog.Extensions.Logging/project.json
+++ b/src/Serilog.Extensions.Logging/project.json
@@ -9,7 +9,7 @@
     "iconUrl": "http://serilog.net/images/serilog-extension-nuget.png"
   },
   "dependencies": {
-    "Microsoft.Extensions.Logging": "1.0.0-rc2-final",
+    "Microsoft.Extensions.Logging.Abstractions": "1.0.0-rc2-final",
     "Serilog": "2.0.0-rc-576"
   },
   "buildOptions": {
@@ -19,9 +19,7 @@
   },
   "frameworks": {
     "net4.5": {
-      "frameworkAssemblies": {
-        "System.Runtime": ""
-      }
+      "dependencies": { "System.Runtime": "4.0.0" }
     },
     "netstandard1.3": {
       "buildOptions": {


### PR DESCRIPTION
Needs to reference 4.0.0 specifically.

Also retargeted against _m.e.Logging.Abstractions_ since that's the appropriate package to depend upon.