### PR TITLE
Added functionality to support the destructurer operator in BeginScope.

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
@@ -58,7 +58,16 @@ namespace Serilog.Extensions.Logging
                     if (stateProperty.Key == SerilogLoggerProvider.OriginalFormatPropertyName && stateProperty.Value is string)
                         continue;
 
-                    var property = propertyFactory.CreateProperty(stateProperty.Key, stateProperty.Value);
+                    var key = stateProperty.Key;
+                    var destructureObject = false;
+
+                    if (key.StartsWith("@"))
+                    {
+                        key = key.Substring(1);
+                        destructureObject = true;
+                    }
+                    
+                    var property = propertyFactory.CreateProperty(key, stateProperty.Value, destructureObject);
                     logEvent.AddPropertyIfAbsent(property);
                 }
             }


### PR DESCRIPTION
Modified the SerilogLoggerScope to allow the usage of the destructurer operator ("@") to destructure an object when enriching the log event.  When this happens, the key for the property will then also have the "@" symbol removed as the first character.

Note: On my local copy, I had to invert the order of net4.6 and netcoreapp1.0 in the frameworks section in order for Visual Studio 2015 to detect the unit tests in the Test Explorer. I wasn't sure if this was just something wrong with my computer though, so I left it out of this PR.