### PR TITLE
Fixes #50 - include named scopes

### DIFF
--- a/samples/WebSample/Controllers/HomeController.cs
+++ b/samples/WebSample/Controllers/HomeController.cs
@@ -4,15 +4,32 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace WebSample.Controllers
 {
     public class HomeController : Controller
     {
+        ILogger<HomeController> _logger;
+
+        public HomeController(ILogger<HomeController> logger)
+        {
+            _logger = logger;
+        }
+
         public IActionResult Index()
         {
-            Log.Information("Hello from the Index!");
+            _logger.LogInformation("Before");
 
+            using (_logger.BeginScope("Some name"))
+            using (_logger.BeginScope(42))
+            using (_logger.BeginScope("Formatted {WithValue}", 12345))
+            using (_logger.BeginScope(new Dictionary<string, object> { ["ViaDictionary"] = 100 }))
+            {
+                _logger.LogInformation("Hello from the Index!");
+            }
+
+            _logger.LogInformation("After");
             return View();
         }
 
@@ -20,6 +37,7 @@ namespace WebSample.Controllers
         {
             ViewData["Message"] = "Your application description page.";
 
+            // Directly through Serilog
             Log.Information("This is a handler for {Path}", Request.Path);
 
             return View();

--- a/samples/WebSample/appsettings.json
+++ b/samples/WebSample/appsettings.json
@@ -12,7 +12,8 @@
     ],
     "WriteTo": [
       "Trace",
-      "LiterateConsole"
+      "LiterateConsole",
+      {"Name": "Seq", "Args": {"serverUrl": "http://localhost:5341" }}
     ]
   }
 }

--- a/samples/WebSample/project.json
+++ b/samples/WebSample/project.json
@@ -23,7 +23,8 @@
     "Serilog.Extensions.Logging": { "target": "project" },
     "Serilog.Settings.Configuration": "2.1.0-dev-00028",
     "Serilog.Sinks.Trace": "2.0.0",
-    "Serilog.Sinks.Literate": "2.0.0"
+    "Serilog.Sinks.Literate": "2.0.0",
+    "Serilog.Sinks.Seq": "3.1.1"
   },
 
   "tools": {

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
@@ -27,7 +27,7 @@ namespace Serilog.Extensions.Logging
         // May be null; if it is, Log.Logger will be lazily used
         readonly ILogger _logger;
         readonly Action _dispose;
-        readonly bool _includeNamedScopes;
+        readonly bool _ignoreNamedScopes;
 
         /// <summary>
         /// Construct a <see cref="SerilogLoggerProvider"/>.
@@ -61,10 +61,9 @@ namespace Serilog.Extensions.Logging
         /// </summary>
         /// <param name="logger">A Serilog logger to pipe events through; if null, the static <see cref="Log"/> class will be used.</param>
         /// <param name="dispose">If true, the provided logger or static log class will be disposed/closed when the provider is disposed.</param>
-        /// <param name="includeNamedScopes">Indicates whether a <code>Scope</code> property should be generated when
-        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope"/> is called with <see cref="string"/> arguments. The
-        /// default is false.</param>
-        public SerilogLoggerProvider(ILogger logger, bool dispose, bool includeNamedScopes)
+        /// <param name="ignoreNamedScopes">If true, no <code>Scope</code> property will be generated when
+        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope"/> is called with <see cref="string"/> arguments.</param>
+        public SerilogLoggerProvider(ILogger logger, bool dispose, bool ignoreNamedScopes)
         {
             if (logger != null)
                 _logger = logger.ForContext(new[] { this });
@@ -77,7 +76,7 @@ namespace Serilog.Extensions.Logging
                     _dispose = Log.CloseAndFlush;
             }
 
-            _includeNamedScopes = includeNamedScopes;
+            _ignoreNamedScopes = ignoreNamedScopes;
         }
 
         /// <inheritdoc />
@@ -100,7 +99,7 @@ namespace Serilog.Extensions.Logging
                 scope.Enrich(logEvent, propertyFactory);
             }
 
-            if (_includeNamedScopes)
+            if (!_ignoreNamedScopes)
             {
                 List<ScalarValue> names = null;
                 for (var scope = CurrentScope; scope != null; scope = scope.Parent)

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
@@ -109,12 +109,13 @@ namespace Serilog.Extensions.Logging
                     if (scope.TryGetName(out name))
                     {
                         names = names ?? new List<ScalarValue>();
-                        names.Insert(0, new ScalarValue(name));
+                        names.Add(new ScalarValue(name));
                     }
                 }
 
                 if (names != null)
                 {
+                    names.Reverse();
                     logEvent.AddPropertyIfAbsent(new LogEventProperty(ScopePropertyName, new SequenceValue(names)));
                 }
             }

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Serilog.Core;
 using Serilog.Events;
 using FrameworkLogger = Microsoft.Extensions.Logging.ILogger;
+using System.Collections.Generic;
 
 namespace Serilog.Extensions.Logging
 {
@@ -21,17 +22,49 @@ namespace Serilog.Extensions.Logging
     public class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher
     {
         internal const string OriginalFormatPropertyName = "{OriginalFormat}";
+        internal const string ScopePropertyName = "Scope";
 
         // May be null; if it is, Log.Logger will be lazily used
         readonly ILogger _logger;
         readonly Action _dispose;
+        readonly bool _includeNamedScopes;
+
+        /// <summary>
+        /// Construct a <see cref="SerilogLoggerProvider"/>.
+        /// </summary>
+        public SerilogLoggerProvider()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Construct a <see cref="SerilogLoggerProvider"/>.
+        /// </summary>
+        /// <param name="logger">A Serilog logger to pipe events through; if null, the static <see cref="Log"/> class will be used.</param>
+        public SerilogLoggerProvider(ILogger logger)
+            : this(logger, false)
+        {
+        }
 
         /// <summary>
         /// Construct a <see cref="SerilogLoggerProvider"/>.
         /// </summary>
         /// <param name="logger">A Serilog logger to pipe events through; if null, the static <see cref="Log"/> class will be used.</param>
         /// <param name="dispose">If true, the provided logger or static log class will be disposed/closed when the provider is disposed.</param>
-        public SerilogLoggerProvider(ILogger logger = null, bool dispose = false)
+        public SerilogLoggerProvider(ILogger logger, bool dispose)
+            : this(logger, dispose, false)
+        {
+        }
+
+        /// <summary>
+        /// Construct a <see cref="SerilogLoggerProvider"/>.
+        /// </summary>
+        /// <param name="logger">A Serilog logger to pipe events through; if null, the static <see cref="Log"/> class will be used.</param>
+        /// <param name="dispose">If true, the provided logger or static log class will be disposed/closed when the provider is disposed.</param>
+        /// <param name="includeNamedScopes">Indicates whether a <code>Scope</code> property should be generated when
+        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope"/> is called with <see cref="string"/> arguments. The
+        /// default is false.</param>
+        public SerilogLoggerProvider(ILogger logger, bool dispose, bool includeNamedScopes)
         {
             if (logger != null)
                 _logger = logger.ForContext(new[] { this });
@@ -43,6 +76,8 @@ namespace Serilog.Extensions.Logging
                 else
                     _dispose = Log.CloseAndFlush;
             }
+
+            _includeNamedScopes = includeNamedScopes;
         }
 
         /// <inheritdoc />
@@ -63,6 +98,25 @@ namespace Serilog.Extensions.Logging
             for (var scope = CurrentScope; scope != null; scope = scope.Parent)
             {
                 scope.Enrich(logEvent, propertyFactory);
+            }
+
+            if (_includeNamedScopes)
+            {
+                List<ScalarValue> names = null;
+                for (var scope = CurrentScope; scope != null; scope = scope.Parent)
+                {
+                    string name;
+                    if (scope.TryGetName(out name))
+                    {
+                        names = names ?? new List<ScalarValue>();
+                        names.Insert(0, new ScalarValue(name));
+                    }
+                }
+
+                if (names != null)
+                {
+                    logEvent.AddPropertyIfAbsent(new LogEventProperty(ScopePropertyName, new SequenceValue(names)));
+                }
             }
         }
 

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
@@ -72,5 +72,11 @@ namespace Serilog.Extensions.Logging
                 }
             }
         }
+
+        public bool TryGetName(out string name)
+        {
+            name = _state as string;
+            return name != null;
+        }
     }
 }

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
@@ -3,29 +3,30 @@
 
 using System;
 using System.Collections.Generic;
-using Serilog.Context;
 using Serilog.Core;
 using Serilog.Events;
 
 namespace Serilog.Extensions.Logging
 {
-    class SerilogLoggerScope : IDisposable, ILogEventEnricher
+    class SerilogLoggerScope : IDisposable
     {
+        const string NoName = "None";
+
         readonly SerilogLoggerProvider _provider;
         readonly object _state;
-        readonly IDisposable _popSerilogContext;
+        readonly IDisposable _chainedDisposable;
 
         // An optimization only, no problem if there are data races on this.
         bool _disposed;
 
-        public SerilogLoggerScope(SerilogLoggerProvider provider, object state)
+        public SerilogLoggerScope(SerilogLoggerProvider provider, object state, IDisposable chainedDisposable = null)
         {
             _provider = provider;
             _state = state;
 
             Parent = _provider.CurrentScope;
             _provider.CurrentScope = this;
-            _popSerilogContext = LogContext.PushProperties(this);
+            _chainedDisposable = chainedDisposable;
         }
 
         public SerilogLoggerScope Parent { get; }
@@ -44,19 +45,30 @@ namespace Serilog.Extensions.Logging
                         _provider.CurrentScope = Parent;
                 }
 
-                _popSerilogContext.Dispose();
+                _chainedDisposable?.Dispose();
             }
         }
 
-        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        public void EnrichAndCreateScopeItem(LogEvent logEvent, ILogEventPropertyFactory propertyFactory, out LogEventPropertyValue scopeItem)
         {
+            if (_state == null)
+            {
+                scopeItem = null;
+                return;
+            }
+
             var stateProperties = _state as IEnumerable<KeyValuePair<string, object>>;
             if (stateProperties != null)
             {
+                scopeItem = null; // Unless it's `FormattedLogValues`, these are treated as property bags rather than scope items.
+
                 foreach (var stateProperty in stateProperties)
                 {
                     if (stateProperty.Key == SerilogLoggerProvider.OriginalFormatPropertyName && stateProperty.Value is string)
+                    {
+                        scopeItem = new ScalarValue(_state.ToString());
                         continue;
+                    }
 
                     var key = stateProperty.Key;
                     var destructureObject = false;
@@ -71,12 +83,10 @@ namespace Serilog.Extensions.Logging
                     logEvent.AddPropertyIfAbsent(property);
                 }
             }
-        }
-
-        public bool TryGetName(out string name)
-        {
-            name = _state as string;
-            return name != null;
+            else
+            {
+                scopeItem = propertyFactory.CreateProperty(NoName, _state).Value;
+            }
         }
     }
 }

--- a/src/Serilog.Extensions.Logging/SerilogLoggerFactoryExtensions.cs
+++ b/src/Serilog.Extensions.Logging/SerilogLoggerFactoryExtensions.cs
@@ -20,19 +20,15 @@ namespace Serilog
         /// <param name="dispose">When true, dispose <paramref name="logger"/> when the framework disposes the provider. If the
         /// logger is not specified but <paramref name="dispose"/> is true, the <see cref="Log.CloseAndFlush()"/> method will be
         /// called on the static <see cref="Log"/> class instead.</param>
-        /// <param name="ignoreNamedScopes">If true, no <code>Scope</code> property will be generated when
-        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope"/> is called with <see cref="string"/> arguments. The
-        /// default is to generate the property.</param>
         /// <returns>The logger factory.</returns>
         public static ILoggerFactory AddSerilog(
             this ILoggerFactory factory,
             ILogger logger = null,
-            bool dispose = false,
-            bool ignoreNamedScopes = false)
+            bool dispose = false)
         {
             if (factory == null) throw new ArgumentNullException(nameof(factory));
 
-            factory.AddProvider(new SerilogLoggerProvider(logger, dispose, ignoreNamedScopes));
+            factory.AddProvider(new SerilogLoggerProvider(logger, dispose));
 
             return factory;
         }

--- a/src/Serilog.Extensions.Logging/SerilogLoggerFactoryExtensions.cs
+++ b/src/Serilog.Extensions.Logging/SerilogLoggerFactoryExtensions.cs
@@ -20,19 +20,19 @@ namespace Serilog
         /// <param name="dispose">When true, dispose <paramref name="logger"/> when the framework disposes the provider. If the
         /// logger is not specified but <paramref name="dispose"/> is true, the <see cref="Log.CloseAndFlush()"/> method will be
         /// called on the static <see cref="Log"/> class instead.</param>
-        /// <param name="includeNamedScopes">Indicates whether a <code>Scope</code> property should be generated when
+        /// <param name="ignoreNamedScopes">If true, no <code>Scope</code> property will be generated when
         /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope"/> is called with <see cref="string"/> arguments. The
-        /// default is false.</param>
+        /// default is to generate the property.</param>
         /// <returns>The logger factory.</returns>
         public static ILoggerFactory AddSerilog(
             this ILoggerFactory factory,
             ILogger logger = null,
             bool dispose = false,
-            bool includeNamedScopes = false)
+            bool ignoreNamedScopes = false)
         {
             if (factory == null) throw new ArgumentNullException(nameof(factory));
 
-            factory.AddProvider(new SerilogLoggerProvider(logger, dispose, includeNamedScopes));
+            factory.AddProvider(new SerilogLoggerProvider(logger, dispose, ignoreNamedScopes));
 
             return factory;
         }

--- a/src/Serilog.Extensions.Logging/SerilogLoggerFactoryExtensions.cs
+++ b/src/Serilog.Extensions.Logging/SerilogLoggerFactoryExtensions.cs
@@ -20,15 +20,19 @@ namespace Serilog
         /// <param name="dispose">When true, dispose <paramref name="logger"/> when the framework disposes the provider. If the
         /// logger is not specified but <paramref name="dispose"/> is true, the <see cref="Log.CloseAndFlush()"/> method will be
         /// called on the static <see cref="Log"/> class instead.</param>
+        /// <param name="includeNamedScopes">Indicates whether a <code>Scope</code> property should be generated when
+        /// <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope"/> is called with <see cref="string"/> arguments. The
+        /// default is false.</param>
         /// <returns>The logger factory.</returns>
         public static ILoggerFactory AddSerilog(
             this ILoggerFactory factory,
             ILogger logger = null,
-            bool dispose = false)
+            bool dispose = false,
+            bool includeNamedScopes = false)
         {
             if (factory == null) throw new ArgumentNullException(nameof(factory));
 
-            factory.AddProvider(new SerilogLoggerProvider(logger, dispose));
+            factory.AddProvider(new SerilogLoggerProvider(logger, dispose, includeNamedScopes));
 
             return factory;
         }

--- a/src/Serilog.Extensions.Logging/project.json
+++ b/src/Serilog.Extensions.Logging/project.json
@@ -21,6 +21,12 @@
     "net4.5": {
       "dependencies": { "System.Runtime": "4.0.0" }
     },
+    "net4.6": {
+      "dependencies": { "System.Runtime": "4.0.20" },
+      "buildOptions": {
+        "define": [ "ASYNCLOCAL" ]
+      }
+    },
     "netstandard1.3": {
       "buildOptions": {
         "define": ["ASYNCLOCAL"]

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
@@ -19,7 +19,7 @@ namespace Serilog.Extensions.Logging.Test
         private const string Name = "test";
         private const string TestMessage = "This is a test";
 
-        private Tuple<SerilogLogger, SerilogSink> SetUp(LogLevel logLevel, bool includeNamedScopes = false)
+        private Tuple<SerilogLogger, SerilogSink> SetUp(LogLevel logLevel)
         {
             var sink = new SerilogSink();
 
@@ -28,7 +28,7 @@ namespace Serilog.Extensions.Logging.Test
 
             SetMinLevel(config, logLevel);
 
-            var provider = new SerilogLoggerProvider(config.CreateLogger(), false, includeNamedScopes);
+            var provider = new SerilogLoggerProvider(config.CreateLogger());
             var logger = (SerilogLogger)provider.CreateLogger(Name);
 
             return new Tuple<SerilogLogger, SerilogSink>(logger, sink);
@@ -365,9 +365,9 @@ namespace Serilog.Extensions.Logging.Test
         }
 
         [Fact]
-        public void NamedScopesAreCapturedWhenRequested()
+        public void NamedScopesAreCaptured()
         {
-            var t = SetUp(LogLevel.Trace, includeNamedScopes: true);
+            var t = SetUp(LogLevel.Trace);
             var logger = t.Item1;
             var sink = t.Item2;
 


### PR DESCRIPTION
When `includeNamedScopes` is specified as `true` in the `AddSerilog()` call, string-valued scope data will be included in a new property called `Scope` on the resulting log events:

```csharp
using (logger.BeginScope("Outer"))
{
    logger.LogInformation("Outer");

    using (logger.BeginScope("Inner"))
    {
        logger.LogInformation("Inner");
    }

    logger.LogInformation("Outer, again");
}

logger.LogInformation("Done");
```

![image](https://cloud.githubusercontent.com/assets/342712/20205046/27e8d1e4-a821-11e6-8321-e9f04ac85c5e.png)

No breaking changes, though a few constructors were added to `SerilogLoggerProvider` to facilitate this.

### Alternatives

The opt-in nature of the change is following the console logger provider, which requires `includeScopes` to be passed for scope information to be recorded.

It could make sense to enable this by default, since developers are essentially opting in with `BeginScope()`, and object-valued (i.e. key-value-pair) scope state is already included.

Thoughts?
