### PR TITLE
1.3.0 Release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
+1.2.0
+
+ * #45 - Make the provider type public so that it can be embedded more easily in other providers
+
 1.1.0
+
  * #41 - Provide a `dispose` flag to instruct provider to take ownership of the Serilog logger
 
 1.0.0
+
  * Initial version
  

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-1.1.0-*
+1.1.0
  * #41 - Provide a `dispose` flag to instruct provider to take ownership of the Serilog logger
 
 1.0.0

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ call `AddSerilog()` on the provided `loggerFactory`.
   public void Configure(IApplicationBuilder app,
                         IHostingEnvironment env,
                         ILoggerFactory loggerfactory,
-			IApplicationLifetime appLifetime)
+                        IApplicationLifetime appLifetime)
   {
       loggerfactory.AddSerilog();
       

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# Serilog.Extensions.Logging 
-[![Build status](https://ci.appveyor.com/api/projects/status/865nohxfiq1rnby0/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-framework-logging/history) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Extensions.Logging.svg?style=flat)](https://www.nuget.org/packages/Serilog.Extensions.Logging/) 
+# Serilog.Extensions.Logging [![Build status](https://ci.appveyor.com/api/projects/status/865nohxfiq1rnby0/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-framework-logging/history) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Extensions.Logging.svg?style=flat)](https://www.nuget.org/packages/Serilog.Extensions.Logging/) 
 
 
 A Serilog provider for [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging), the logging subsystem used by ASP.NET Core.

--- a/samples/WebSample/Controllers/HomeController.cs
+++ b/samples/WebSample/Controllers/HomeController.cs
@@ -4,15 +4,32 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
+using Microsoft.Extensions.Logging;
 
 namespace WebSample.Controllers
 {
     public class HomeController : Controller
     {
+        ILogger<HomeController> _logger;
+
+        public HomeController(ILogger<HomeController> logger)
+        {
+            _logger = logger;
+        }
+
         public IActionResult Index()
         {
-            Log.Information("Hello from the Index!");
+            _logger.LogInformation("Before");
 
+            using (_logger.BeginScope("Some name"))
+            using (_logger.BeginScope(42))
+            using (_logger.BeginScope("Formatted {WithValue}", 12345))
+            using (_logger.BeginScope(new Dictionary<string, object> { ["ViaDictionary"] = 100 }))
+            {
+                _logger.LogInformation("Hello from the Index!");
+            }
+
+            _logger.LogInformation("After");
             return View();
         }
 
@@ -20,6 +37,7 @@ namespace WebSample.Controllers
         {
             ViewData["Message"] = "Your application description page.";
 
+            // Directly through Serilog
             Log.Information("This is a handler for {Path}", Request.Path);
 
             return View();

--- a/samples/WebSample/appsettings.json
+++ b/samples/WebSample/appsettings.json
@@ -12,7 +12,8 @@
     ],
     "WriteTo": [
       "Trace",
-      "LiterateConsole"
+      "LiterateConsole",
+      {"Name": "Seq", "Args": {"serverUrl": "http://localhost:5341" }}
     ]
   }
 }

--- a/samples/WebSample/project.json
+++ b/samples/WebSample/project.json
@@ -23,7 +23,8 @@
     "Serilog.Extensions.Logging": { "target": "project" },
     "Serilog.Settings.Configuration": "2.1.0-dev-00028",
     "Serilog.Sinks.Trace": "2.0.0",
-    "Serilog.Sinks.Literate": "2.0.0"
+    "Serilog.Sinks.Literate": "2.0.0",
+    "Serilog.Sinks.Seq": "3.1.1"
   },
 
   "tools": {

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
@@ -58,7 +58,16 @@ namespace Serilog.Extensions.Logging
                     if (stateProperty.Key == SerilogLoggerProvider.OriginalFormatPropertyName && stateProperty.Value is string)
                         continue;
 
-                    var property = propertyFactory.CreateProperty(stateProperty.Key, stateProperty.Value);
+                    var key = stateProperty.Key;
+                    var destructureObject = false;
+
+                    if (key.StartsWith("@"))
+                    {
+                        key = key.Substring(1);
+                        destructureObject = true;
+                    }
+                    
+                    var property = propertyFactory.CreateProperty(key, stateProperty.Value, destructureObject);
                     logEvent.AddPropertyIfAbsent(property);
                 }
             }

--- a/src/Serilog.Extensions.Logging/project.json
+++ b/src/Serilog.Extensions.Logging/project.json
@@ -21,6 +21,12 @@
     "net4.5": {
       "dependencies": { "System.Runtime": "4.0.0" }
     },
+    "net4.6": {
+      "dependencies": { "System.Runtime": "4.0.20" },
+      "buildOptions": {
+        "define": [ "ASYNCLOCAL" ]
+      }
+    },
     "netstandard1.3": {
       "buildOptions": {
         "define": ["ASYNCLOCAL"]

--- a/src/Serilog.Extensions.Logging/project.json
+++ b/src/Serilog.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0-*",
+  "version": "1.2.0-*",
   "description": "Serilog provider for Microsoft.Extensions.Logging",
   "authors": [ "Microsoft", "Serilog Contributors" ],
   "packOptions": {

--- a/src/Serilog.Extensions.Logging/project.json
+++ b/src/Serilog.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0-*",
+  "version": "1.3.0-*",
   "description": "Serilog provider for Microsoft.Extensions.Logging",
   "authors": [ "Microsoft", "Serilog Contributors" ],
   "packOptions": {


### PR DESCRIPTION
 * #51 - support `@` operator in formatted scope messages
 * #55 - add hierarchical `Scope` property and capture more scope types including `"names"`
