### PR TITLE
Fix issue 928 (Missed EF events)

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -95,21 +95,24 @@ namespace Serilog.Extensions.Logging
                 }
             }
 
-            if (messageTemplate == null && state != null)
+            if (messageTemplate == null)
             {
-                messageTemplate = "{State:l}";
-                LogEventProperty stateProperty;
-                if (logger.BindProperty("State", AsLoggableValue(state, formatter), false, out stateProperty))
-                    properties.Add(stateProperty);
-            }
+                var propertyName = state != null ? "State" :
+                              (formatter != null ? "Message" : null);
 
-            if (string.IsNullOrEmpty(messageTemplate))
-                return;
+                if (propertyName != null)
+                {
+                    messageTemplate = $"{{{propertyName}:l}}";
+                    LogEventProperty property;
+                    if (logger.BindProperty(propertyName, AsLoggableValue(state, formatter), false, out property))
+                        properties.Add(property);
+                }
+            }
 
             if (eventId.Id != 0 || eventId.Name != null)
                 properties.Add(CreateEventIdProperty(eventId));
 
-            var parsedTemplate = _messageTemplateParser.Parse(messageTemplate);
+            var parsedTemplate = _messageTemplateParser.Parse(messageTemplate ?? "");
             var evt = new LogEvent(DateTimeOffset.Now, level, exception, parsedTemplate, properties);
             logger.Write(evt);
         }

--- a/src/Serilog.Extensions.Logging/project.json
+++ b/src/Serilog.Extensions.Logging/project.json
@@ -19,10 +19,8 @@
   },
   "frameworks": {
     "net4.5": {
-      "dependencies": { "System.Runtime": "4.0.0" }
     },
     "net4.6": {
-      "dependencies": { "System.Runtime": "4.0.20" },
       "buildOptions": {
         "define": [ "ASYNCLOCAL" ]
       }
@@ -30,9 +28,6 @@
     "netstandard1.3": {
       "buildOptions": {
         "define": ["ASYNCLOCAL"]
-      },
-      "dependencies": {
-        "System.Threading": "4.0.11"
       }
     }
   }

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
@@ -152,9 +152,20 @@ namespace Serilog.Extensions.Logging.Test
 
             logger.Log<object>(LogLevel.Information, 0, null, null, null);
             logger.Log(LogLevel.Information, 0, TestMessage, null, null);
+            logger.Log<object>(LogLevel.Information, 0, null, null, (_, __) => TestMessage);
 
-            Assert.Equal(1, sink.Writes.Count);
-            Assert.Equal(TestMessage, sink.Writes[0].RenderMessage());
+            Assert.Equal(3, sink.Writes.Count);
+
+            Assert.Equal(1, sink.Writes[0].Properties.Count);
+            Assert.Empty(sink.Writes[0].RenderMessage());
+
+            Assert.Equal(2, sink.Writes[1].Properties.Count);
+            Assert.True(sink.Writes[1].Properties.ContainsKey("State"));
+            Assert.Equal(TestMessage, sink.Writes[1].RenderMessage());
+
+            Assert.Equal(2, sink.Writes[2].Properties.Count);
+            Assert.True(sink.Writes[2].Properties.ContainsKey("Message"));
+            Assert.Equal(TestMessage, sink.Writes[2].RenderMessage());
         }
 
         [Fact]

--- a/test/Serilog.Extensions.Logging.Tests/project.json
+++ b/test/Serilog.Extensions.Logging.Tests/project.json
@@ -9,7 +9,6 @@
     "keyFile": "../../assets/Serilog.snk"
   },
   "frameworks": {
-    "net4.6": { },
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
@@ -21,7 +20,8 @@
         "dnxcore50",
         "portable-net45+win8"
       ]
-    }
+    },
+    "net4.6": {}
   }
 }
 


### PR DESCRIPTION
- fixes [#928](https://github.com/serilog/serilog/issues/928) making it less restrictive on a passed parameters
- some dependencies cleanup to get rid of warning