### PR TITLE
Update to netstandard 2.0 rtm dependencies / tooling

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -20,7 +20,7 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
-    & dotnet pack -c Release --include-symbols -o ..\..\artifacts --version-suffix=$suffix
+    & dotnet pack -c Release --include-source -o ..\..\artifacts --version-suffix=$suffix
     if($LASTEXITCODE -ne 0) { exit 1 }    
 
     Pop-Location

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2017 Preview
 configuration: Release
 install:
   - ps: mkdir -Force ".\build\" | Out-Null
-  #- ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0-preview2/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
+  #- ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.ps1" -OutFile ".\build\installcli.ps1"
   #- ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetcli"
   #- ps: '& .\build\installcli.ps1 -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath -Version 2.0.0-preview2-006497'
   #- ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"

--- a/samples/Sample/Sample.csproj
+++ b/samples/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Sample</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Sample</PackageId>
@@ -12,17 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0-preview2-final" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="2.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/samples/WebSample/WebSample.csproj
+++ b/samples/WebSample/WebSample.csproj
@@ -4,8 +4,6 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>WebSample</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>WebSample</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Update="wwwroot\**\*;Views\**\*;Areas\**\Views">
@@ -23,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0-preview2-final" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.0.2" />

--- a/src/Serilog.Extensions.Logging/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Extensions.Logging/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
 
 [assembly: InternalsVisibleTo("Serilog.Extensions.Logging.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -4,7 +4,7 @@
     <Description>Serilog provider for Microsoft.Extensions.Logging</Description>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Microsoft;Serilog Contributors</Authors>
-    <TargetFrameworks>net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;net461;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Extensions.Logging</AssemblyName>
@@ -17,42 +17,28 @@
     <PackageProjectUrl>https://github.com/serilog/serilog-extensions-logging</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <!-- Don't reference the full NETStandard.Library -->
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Runtime" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
+    
     <Compile Remove="SerilogLoggingBuilderExtensions.cs" />
+    <None Include="SerilogLoggingBuilderExtensions.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <Reference Include="System.Runtime" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0-preview2-final" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.0-preview2-25401-01" />
-    <Compile Remove="SerilogLoggerFactoryExtensions.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0" />
-    <Compile Remove="SerilogLoggingBuilderExtensions.cs" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0-preview2-final" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.0-preview2-25401-01" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <DefineConstants>$(DefineConstants);ASYNCLOCAL</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <DefineConstants>$(DefineConstants);ASYNCLOCAL</DefineConstants>
   </PropertyGroup>
 

--- a/src/Serilog.Extensions.Logging/SerilogLoggerFactoryExtensions.cs
+++ b/src/Serilog.Extensions.Logging/SerilogLoggerFactoryExtensions.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Serilog.Extensions.Logging;
-using System.ComponentModel;
 
 namespace Serilog
 {
@@ -13,21 +12,6 @@ namespace Serilog
     /// </summary>
     public static class SerilogLoggerFactoryExtensions
     {
-        /// <summary>
-        /// Add Serilog to the logging pipeline.
-        /// </summary>
-        /// <param name="factory">The logger factory to configure.</param>
-        /// <param name="logger">The Serilog logger; if not supplied, the static <see cref="Serilog.Log"/> will be used.</param>
-        /// <returns>The logger factory.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ILoggerFactory AddSerilog(
-            this ILoggerFactory factory,
-            ILogger logger)
-        {
-            if (factory == null) throw new ArgumentNullException(nameof(factory));
-            return factory.AddSerilog(logger, false);
-        }
-
         /// <summary>
         /// Add Serilog to the logging pipeline.
         /// </summary>

--- a/test/Serilog.Extensions.Logging.Tests/Serilog.Extensions.Logging.Tests.csproj
+++ b/test/Serilog.Extensions.Logging.Tests/Serilog.Extensions.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0;net46;net461</TargetFrameworks>
     <AssemblyName>Serilog.Extensions.Logging.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
- updated tooling
- added `net461` target (to pair with `netstandard2.0`)
- bumped `AssemblyVersion`
- simplified `csproj` a bit
- removed obsolete `ILoggerFactory.AddSerilog` method