### PR TITLE
Fix build script running on .net core 2.0 CLI

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -20,7 +20,12 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
-    & dotnet pack -c Release --include-source -o ..\..\artifacts --version-suffix=$suffix
+    if($suffix) {
+        & dotnet pack -c Release --include-source -o ..\..\artifacts --version-suffix=$suffix
+    } else {
+        & dotnet pack -c Release --include-source -o ..\..\artifacts
+    }
+    
     if($LASTEXITCODE -ne 0) { exit 1 }    
 
     Pop-Location


### PR DESCRIPTION
should fix https://ci.appveyor.com/project/serilog/serilog-framework-logging/build/10175