### PR TITLE
Cache low-numbered numeric event ids to reduce allocations

### DIFF
--- a/serilog-extensions-logging.sln
+++ b/serilog-extensions-logging.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.10
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29209.62
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A1893BD1-333D-4DFE-A0F0-DDBB2FE526E0}"
 EndProject
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{9C21B9
 		assets\Serilog.snk = assets\Serilog.snk
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Extensions.Logging.Benchmarks", "test\Serilog.Extensions.Logging.Benchmarks\Serilog.Extensions.Logging.Benchmarks.csproj", "{6D5986FF-EECD-4E75-8BC6-A5F78AB549B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +44,10 @@ Global
 		{65357FBC-9BC4-466D-B621-1C3A19BC2A78}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65357FBC-9BC4-466D-B621-1C3A19BC2A78}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65357FBC-9BC4-466D-B621-1C3A19BC2A78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D5986FF-EECD-4E75-8BC6-A5F78AB549B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D5986FF-EECD-4E75-8BC6-A5F78AB549B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D5986FF-EECD-4E75-8BC6-A5F78AB549B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D5986FF-EECD-4E75-8BC6-A5F78AB549B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -50,6 +56,7 @@ Global
 		{903CD13A-D54B-4CEC-A55F-E22AE3D93B3B} = {A1893BD1-333D-4DFE-A0F0-DDBB2FE526E0}
 		{37EADF84-5E41-4224-A194-1E3299DCD0B8} = {E30F638E-BBBE-4AD1-93CE-48CC69CFEFE1}
 		{65357FBC-9BC4-466D-B621-1C3A19BC2A78} = {F2407211-6043-439C-8E06-3641634332E7}
+		{6D5986FF-EECD-4E75-8BC6-A5F78AB549B2} = {E30F638E-BBBE-4AD1-93CE-48CC69CFEFE1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {811E61C5-3871-4633-AFAE-B35B619C8A10}

--- a/serilog-extensions-logging.sln.DotSettings
+++ b/serilog-extensions-logging.sln.DotSettings
@@ -1,7 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=destructure/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=destructured/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Destructurer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Destructures/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enricher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=enrichers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Loggable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nonscalar/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=sobj/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/test/Serilog.Extensions.Logging.Benchmarks/LogEventConstructionBenchmark.cs
+++ b/test/Serilog.Extensions.Logging.Benchmarks/LogEventConstructionBenchmark.cs
@@ -1,0 +1,103 @@
+﻿// Copyright 2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+using Microsoft.Extensions.Logging;
+using IMelLogger = Microsoft.Extensions.Logging.ILogger;
+using Serilog.Events;
+using Serilog.Extensions.Logging.Benchmarks.Support;
+using Xunit;
+
+namespace Serilog.Extensions.Logging.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class LogEventConstructionBenchmark
+    {
+        readonly IMelLogger _melLogger;
+        readonly ILogger _serilogContextualLogger;
+        readonly CapturingSink _sink;
+        const int LowId = 10, HighId = 101;
+        const string Template = "This is an event";
+
+        public LogEventConstructionBenchmark()
+        {
+            _sink = new CapturingSink();
+            var underlyingLogger = new LoggerConfiguration().WriteTo.Sink(_sink).CreateLogger();
+            _serilogContextualLogger = underlyingLogger.ForContext<LogEventConstructionBenchmark>();
+            _melLogger = new SerilogLoggerProvider(underlyingLogger).CreateLogger(GetType().FullName);
+        }
+
+        static void VerifyEventId(LogEvent evt, int? expectedId)
+        {
+            if (evt == null) throw new ArgumentNullException(nameof(evt));
+            if (expectedId == null)
+            {
+                Assert.False(evt.Properties.TryGetValue("EventId", out _));
+            }
+            else
+            {
+                Assert.True(evt.Properties.TryGetValue("EventId", out var eventIdValue));
+                var structure = Assert.IsType<StructureValue>(eventIdValue);
+                var idValue = Assert.Single(structure.Properties, p => p.Name == "Id")?.Value;
+                var scalar = Assert.IsType<ScalarValue>(idValue);
+                Assert.Equal(expectedId.Value, scalar.Value);
+            }
+        }
+
+        [Fact]
+        public void Verify()
+        {
+            VerifyEventId(Native(), null);
+            VerifyEventId(NoId(), null);
+            VerifyEventId(LowNumbered(), LowId);
+            VerifyEventId(HighNumbered(), HighId);
+        }
+
+        [Fact]
+        public void Benchmark()
+        {
+            BenchmarkRunner.Run<LogEventConstructionBenchmark>();
+        }
+
+        [Benchmark(Baseline = true)]
+        public LogEvent Native()
+        {
+            _serilogContextualLogger.Information(Template);
+            return _sink.Collect();
+        }
+
+        [Benchmark]
+        public LogEvent NoId()
+        {
+            _melLogger.LogInformation(Template);
+            return _sink.Collect();
+        }
+
+        [Benchmark]
+        public LogEvent LowNumbered()
+        {
+            _melLogger.LogInformation(LowId, Template);
+            return _sink.Collect();
+        }
+
+        [Benchmark]
+        public LogEvent HighNumbered()
+        {
+            _melLogger.LogInformation(HighId, Template);
+            return _sink.Collect();
+        }
+    }
+}

--- a/test/Serilog.Extensions.Logging.Benchmarks/Serilog.Extensions.Logging.Benchmarks.csproj
+++ b/test/Serilog.Extensions.Logging.Benchmarks/Serilog.Extensions.Logging.Benchmarks.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Extensions.Logging\Serilog.Extensions.Logging.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
+</Project>

--- a/test/Serilog.Extensions.Logging.Benchmarks/Support/CapturingSink.cs
+++ b/test/Serilog.Extensions.Logging.Benchmarks/Support/CapturingSink.cs
@@ -1,0 +1,36 @@
+﻿// Copyright 2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Extensions.Logging.Benchmarks.Support
+{
+    class CapturingSink : ILogEventSink
+    {
+        LogEvent _emitted;
+
+        public void Emit(LogEvent logEvent)
+        {
+            _emitted = logEvent;
+        }
+
+        public LogEvent Collect()
+        {
+            var collected = _emitted;
+            _emitted = null;
+            return collected;
+        }
+    }
+}

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
@@ -16,56 +16,28 @@ namespace Serilog.Extensions.Logging.Tests
 {
     public class SerilogLoggerTest
     {
-        private const string Name = "test";
-        private const string TestMessage = "This is a test";
+        const string Name = "test";
+        const string TestMessage = "This is a test";
 
-        private Tuple<SerilogLogger, SerilogSink> SetUp(LogLevel logLevel)
+        static Tuple<SerilogLogger, SerilogSink> SetUp(LogLevel logLevel)
         {
             var sink = new SerilogSink();
 
-            var config = new LoggerConfiguration()
-                .WriteTo.Sink(sink);
+            var serilogLogger = new LoggerConfiguration()
+                .WriteTo.Sink(sink)
+                .MinimumLevel.Is(LevelMapping.ToSerilogLevel(logLevel))
+                .CreateLogger();
 
-            SetMinLevel(config, logLevel);
-
-            var provider = new SerilogLoggerProvider(config.CreateLogger());
+            var provider = new SerilogLoggerProvider(serilogLogger);
             var logger = (SerilogLogger)provider.CreateLogger(Name);
 
             return new Tuple<SerilogLogger, SerilogSink>(logger, sink);
         }
 
-        private void SetMinLevel(LoggerConfiguration serilog, LogLevel logLevel)
-        {
-            serilog.MinimumLevel.Is(MapLevel(logLevel));
-        }
-
-        private LogEventLevel MapLevel(LogLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LogLevel.Trace:
-                    return LogEventLevel.Verbose;
-                case LogLevel.Debug:
-                    return LogEventLevel.Debug;
-                case LogLevel.Information:
-                    return LogEventLevel.Information;
-                case LogLevel.Warning:
-                    return LogEventLevel.Warning;
-                case LogLevel.Error:
-                    return LogEventLevel.Error;
-                case LogLevel.Critical:
-                    return LogEventLevel.Fatal;
-                default:
-                    return LogEventLevel.Verbose;
-            }
-        }
-
         [Fact]
         public void LogsWhenNullFilterGiven()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             logger.Log(LogLevel.Information, 0, TestMessage, null, null);
 
@@ -75,9 +47,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void LogsCorrectLevel()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             logger.Log(LogLevel.Trace, 0, TestMessage, null, null);
             logger.Log(LogLevel.Debug, 0, TestMessage, null, null);
@@ -134,9 +104,7 @@ namespace Serilog.Extensions.Logging.Tests
         [InlineData(LogLevel.Critical, LogLevel.Critical, 1)]
         public void LogsWhenEnabled(LogLevel minLevel, LogLevel logLevel, int expected)
         {
-            var t = SetUp(minLevel);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(minLevel);
 
             logger.Log(logLevel, 0, TestMessage, null, null);
 
@@ -146,9 +114,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void LogsCorrectMessage()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             logger.Log<object>(LogLevel.Information, 0, null, null, null);
             logger.Log(LogLevel.Information, 0, TestMessage, null, null);
@@ -171,9 +137,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void CarriesException()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             var exception = new Exception();
 
@@ -186,9 +150,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void SingleScopeProperty()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             using (logger.BeginScope(new FoodScope("pizza")))
             {
@@ -203,9 +165,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void NestedScopeSameProperty()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             using (logger.BeginScope(new FoodScope("avocado")))
             {
@@ -224,9 +184,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void NestedScopesDifferentProperties()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             using (logger.BeginScope(new FoodScope("spaghetti")))
             {
@@ -249,9 +207,7 @@ namespace Serilog.Extensions.Logging.Tests
             var selfLog = new StringWriter();
             SelfLog.Enable(selfLog);
 
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             logger.LogInformation("Hello, {Recipient}", "World");
 
@@ -266,11 +222,9 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void CarriesEventIdIfNonzero()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
-            int expected = 42;
+            const int expected = 42;
 
             logger.Log(LogLevel.Information, expected, "Test", null, null);
 
@@ -302,9 +256,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void BeginScopeDestructuresObjectsWhenDestructurerIsUsedInMessageTemplate()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             using (logger.BeginScope("{@Person}", new Person { FirstName = "John", LastName = "Smith" }))
             {
@@ -324,9 +276,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void BeginScopeDestructuresObjectsWhenDestructurerIsUsedInDictionary()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
             
             using (logger.BeginScope(new Dictionary<string, object> {{ "@Person", new Person { FirstName = "John", LastName = "Smith" }}}))
             {
@@ -346,9 +296,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void BeginScopeDoesNotModifyKeyWhenDestructurerIsNotUsedInMessageTemplate()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             using (logger.BeginScope("{FirstName}", "John"))
             {
@@ -362,9 +310,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void BeginScopeDoesNotModifyKeyWhenDestructurerIsNotUsedInDictionary()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             using (logger.BeginScope(new Dictionary<string, object> { { "FirstName", "John"}}))
             {
@@ -378,9 +324,7 @@ namespace Serilog.Extensions.Logging.Tests
         [Fact]
         public void NamedScopesAreCaptured()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+            var (logger, sink) = SetUp(LogLevel.Trace);
 
             using (logger.BeginScope("Outer"))
             using (logger.BeginScope("Inner"))
@@ -390,16 +334,15 @@ namespace Serilog.Extensions.Logging.Tests
 
             Assert.Equal(1, sink.Writes.Count);
 
-            LogEventPropertyValue scopeValue;
-            Assert.True(sink.Writes[0].Properties.TryGetValue(SerilogLoggerProvider.ScopePropertyName, out scopeValue));
-
-            var items = (scopeValue as SequenceValue)?.Elements.Select(e => ((ScalarValue)e).Value).Cast<string>().ToArray();
+            Assert.True(sink.Writes[0].Properties.TryGetValue(SerilogLoggerProvider.ScopePropertyName, out var scopeValue));
+            var sequence = Assert.IsType<SequenceValue>(scopeValue);
+            var items = sequence.Elements.Select(e => Assert.IsType<ScalarValue>(e).Value).Cast<string>().ToArray();
             Assert.Equal(2, items.Length);
             Assert.Equal("Outer", items[0]);
             Assert.Equal("Inner", items[1]);
         }
 
-        private class FoodScope : IEnumerable<KeyValuePair<string, object>>
+        class FoodScope : IEnumerable<KeyValuePair<string, object>>
         {
             readonly string _name;
 
@@ -419,7 +362,7 @@ namespace Serilog.Extensions.Logging.Tests
             }
         }
 
-        private class LuckyScope : IEnumerable<KeyValuePair<string, object>>
+        class LuckyScope : IEnumerable<KeyValuePair<string, object>>
         {
             readonly int _luckyNumber;
 
@@ -439,10 +382,29 @@ namespace Serilog.Extensions.Logging.Tests
             }
         }
 
-        private class Person
+        class Person
         {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
             public string FirstName { get; set; }
+
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
             public string LastName { get; set; }
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(48)]
+        [InlineData(100)]
+        public void LowAndHighNumberedEventIdsAreMapped(int id)
+        {
+            var orig = new EventId(id, "test");
+            var mapped = SerilogLogger.CreateEventIdProperty(orig);
+            var value = Assert.IsType<StructureValue>(mapped.Value);
+            Assert.Equal(2, value.Properties.Count);
+            var idValue = value.Properties.Single(p => p.Name == "Id").Value;
+            var scalar = Assert.IsType<ScalarValue>(idValue);
+            Assert.Equal(id, scalar.Value);
         }
     }
 }

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
@@ -25,7 +25,7 @@ namespace Serilog.Extensions.Logging.Tests
 
             var serilogLogger = new LoggerConfiguration()
                 .WriteTo.Sink(sink)
-                .MinimumLevel.Is(LevelMapping.ToSerilogLevel(logLevel))
+                .MinimumLevel.Is(LevelConvert.ToSerilogLevel(logLevel))
                 .CreateLogger();
 
             var provider = new SerilogLoggerProvider(serilogLogger);


### PR DESCRIPTION
This is a quick improvement for #118. Needs a benchmark to measure allocs.