### PR TITLE
Use method BindMessageTemplate to improve performance and memory usage

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -77,8 +77,9 @@ namespace Serilog.Extensions.Logging
                 {
                     propertyValues = new object[structure.Count - 1];
 
-                    foreach (var property in structure)
+                    for (int i = 0; i < structure.Count; i++)
                     {
+                        var property = structure[i];
                         if (property.Key == SerilogLoggerProvider.OriginalFormatPropertyName && property.Value is string value)
                         {
                             messageTemplate = value;


### PR DESCRIPTION
Performs 40-45% faster and uses 40-50% less memory for repeated messages.

### Benchmarks
[Link to benchmarks source code](https://github.com/Maxim-Kornilov/serilog-extensions-logging/blob/PullRequestBenchmarks/test/Benchmarks/Program.cs)

``` ini
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.18362
Intel Core i5-8400 CPU 2.80GHz (Coffee Lake), 1 CPU, 6 logical and 6 physical cores
.NET Core SDK=2.2.105
  [Host]     : .NET Core 2.2.3 (CoreCLR 4.6.27414.05, CoreFX 4.6.27414.05), X64 RyuJIT
  DefaultJob : .NET Core 2.2.3 (CoreCLR 4.6.27414.05, CoreFX 4.6.27414.05), X64 RyuJIT
```

#### Before
|               Method |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Allocated |
|--------------------- |---------:|----------:|----------:|------:|-------:|----------:|
|              Serilog | 2.900 us | 0.0052 us | 0.0049 us |  1.00 | 0.3395 |   1.58 KB |
|            Extension | 6.579 us | 0.0281 us | 0.0263 us |  2.27 | 0.7935 |   3.66 KB |
| ExtensionWithEventId | 6.891 us | 0.0079 us | 0.0070 us |  2.38 | 0.8316 |   3.84 KB |

#### After
|               Method |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Allocated |
|--------------------- |---------:|----------:|----------:|------:|-------:|----------:|
|              Serilog | 2.923 us | 0.0073 us | 0.0068 us |  1.00 | 0.3395 |   1.58 KB |
|            Extension | 3.590 us | 0.0182 us | 0.0171 us |  1.23 | 0.4120 |   1.91 KB |
| ExtensionWithEventId | 3.805 us | 0.0061 us | 0.0057 us |  1.30 | 0.4654 |   2.15 KB |