### PR TITLE
Pin .NET Core SDK version to latest feature band

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "2.2.103"
+    "allowPrerelease": false,
+    "version": "3.1.100",
+    "rollForward": "latestPatch"
   }
 }

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -20,7 +20,6 @@
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <RootNamespace>Serilog</RootNamespace>
-    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pin the .NET Core SDK version to the `3.1.1xx` feature band. Do not allow prerelease versions.

Pinning to the feature band (e.g. 3.1.1xx) seems to give the right trade off between build consistency and developer friendliness.

Also, since C# 7.3 is the default language version for `netstandard2.0`, it is not necessary to explicitly specify it.