### PR TITLE
Cache parsed message templates

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/CachingMessageTemplateParser.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/CachingMessageTemplateParser.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+using System;
+using Serilog.Events;
+using Serilog.Parsing;
+using System.Collections;
+
+namespace Serilog.Extensions.Logging
+{
+    class CachingMessageTemplateParser
+    {
+        readonly MessageTemplateParser _innerParser = new MessageTemplateParser();
+        
+        readonly object _templatesLock = new object();
+        readonly Hashtable _templates = new Hashtable();
+
+        const int MaxCacheItems = 1000;
+        const int MaxCachedTemplateLength = 1024;
+
+        public MessageTemplate Parse(string messageTemplate)
+        {
+            if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
+
+            if (messageTemplate.Length > MaxCachedTemplateLength)
+                return _innerParser.Parse(messageTemplate);
+
+            // ReSharper disable once InconsistentlySynchronizedField
+            // ignored warning because this is by design
+            var result = (MessageTemplate)_templates[messageTemplate];
+            if (result != null)
+                return result;
+
+            result = _innerParser.Parse(messageTemplate);
+
+            lock (_templatesLock)
+            {
+                // Exceeding MaxCacheItems is *not* the sunny day scenario; all we're doing here is preventing out-of-memory
+                // conditions when the library is used incorrectly. Correct use (templates, rather than
+                // direct message strings) should barely, if ever, overflow this cache.
+
+                // Changing workloads through the lifecycle of an app instance mean we can gain some ground by
+                // potentially dropping templates generated only in startup, or only during specific infrequent
+                // activities.
+
+                if (_templates.Count == MaxCacheItems)
+                    _templates.Clear();
+
+                _templates[messageTemplate] = result;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -9,7 +9,6 @@ using Serilog.Core;
 using Serilog.Events;
 using FrameworkLogger = Microsoft.Extensions.Logging.ILogger;
 using System.Reflection;
-using Serilog.Parsing;
 
 namespace Serilog.Extensions.Logging
 {
@@ -18,7 +17,7 @@ namespace Serilog.Extensions.Logging
         readonly SerilogLoggerProvider _provider;
         readonly ILogger _logger;
 
-        static readonly MessageTemplateParser MessageTemplateParser = new MessageTemplateParser();
+        static readonly CachingMessageTemplateParser MessageTemplateParser = new CachingMessageTemplateParser();
 
         // It's rare to see large event ids, as they are category-specific
         static readonly LogEventProperty[] LowEventIdValues = Enumerable.Range(0, 48)


### PR DESCRIPTION
This integrates the well-tested template cache from `serilog/serilog`. In general, this will reduce allocations and speed up logging when events use templates properly (16 GB T470p):

**Before**

|       Method |       Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |-----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|       Native |   370.5 ns |  7.067 ns |  6.265 ns |  1.00 |    0.00 | 0.0887 |     - |     - |     280 B |
|         NoId | 1,017.8 ns | 10.906 ns |  9.107 ns |  2.75 |    0.04 | 0.2785 |     - |     - |     880 B |
|  LowNumbered | 1,318.5 ns | 11.772 ns | 10.435 ns |  3.56 |    0.06 | 0.3529 |     - |     - |    1112 B |
| HighNumbered | 1,363.2 ns | 20.672 ns | 18.325 ns |  3.68 |    0.07 | 0.3777 |     - |     - |    1192 B |

**After**

|       Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |---------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|       Native | 362.2 ns |  3.419 ns |  3.031 ns |  1.00 |    0.00 | 0.0887 |     - |     - |     280 B |
|         NoId | 604.3 ns | 11.431 ns | 10.133 ns |  1.67 |    0.03 | 0.1421 |     - |     - |     448 B |
|  LowNumbered | 843.9 ns | 12.429 ns | 11.018 ns |  2.33 |    0.04 | 0.2155 |     - |     - |     680 B |
| HighNumbered | 878.3 ns | 17.330 ns | 16.211 ns |  2.43 |    0.03 | 0.2413 |     - |     - |     760 B |

Performance might regress in apps that (mis)use string concatenation to construct log messages, but the benefits for carefully-written have been found to outweigh this downside in our experiences with Serilog to date.