### PR TITLE
Bump Serilog version dependency to support Unity and .netstandard 2.0+

### DIFF
--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I am trying to use this library in the Unity game engine but it only supports .NET Standard 2.0 onwards and the latest version of Serilog.Extensions.Logging still depends on Serilog 2.8.0 which in turn depends on System.Collections.NonGeneric and this in turn only targets .NET Standard 1.3.

https://docs.unity3d.com/Manual/dotnetProfileSupport.html

Simply upgrading from 2.8.0 to 2.9.0 solves the problem.