### PR TITLE
Add more context information to SelfLog if log statement fails

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -66,7 +66,7 @@ namespace Serilog.Extensions.Logging
             }
             catch (Exception ex)
             {
-                SelfLog.WriteLine($"Failed to write event through {typeof(SerilogLogger).Name}: {ex}");
+                SelfLog.WriteLine($"Failed to write event through {typeof(SerilogLogger).Name}: {ex}\n{new System.Diagnostics.StackTrace()}");
             }
         }
 


### PR DESCRIPTION
by appending the current stacktrace to the exception and its stacktrace.
Fixes #198