### PR TITLE
v7 - pin to `Microsoft.Extensions.Logging` v7

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -11,7 +11,7 @@ if(Test-Path .\artifacts) {
 
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
-$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
+$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "main" -and $revision -ne "local"]
 
 echo "build: Version suffix is $suffix"
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,6 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serilog.Extensions.Logging [![Build status](https://ci.appveyor.com/api/projects/status/865nohxfiq1rnby0/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-framework-logging/history) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Extensions.Logging.svg?style=flat)](https://www.nuget.org/packages/Serilog.Extensions.Logging/) 
+# Serilog.Extensions.Logging [![Build status](https://ci.appveyor.com/api/projects/status/865nohxfiq1rnby0/branch/master?svg=true)](https://ci.appveyor.com/project/serilog/serilog-framework-logging/history) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Extensions.Logging.svg?style=flat)](https://www.nuget.org/packages/Serilog.Extensions.Logging/)
 
 A Serilog provider for [Microsoft.Extensions.Logging](https://www.nuget.org/packages/Microsoft.Extensions.Logging), the logging subsystem used by ASP.NET Core.
 
@@ -16,9 +16,9 @@ The package implements `AddSerilog()` on `ILoggingBuilder` and `ILoggerFactory` 
 
 **First**, install the _Serilog.Extensions.Logging_ [NuGet package](https://www.nuget.org/packages/Serilog.Extensions.Logging) into your web or console app. You will need a way to view the log messages - _Serilog.Sinks.Console_ writes these to the console.
 
-```powershell
-Install-Package Serilog.Extensions.Logging -DependencyVersion Highest
-Install-Package Serilog.Sinks.Console
+```sh
+dotnet add package Serilog.Extensions.Logging
+dotnet add package Serilog.Sinks.Console
 ```
 
 **Next**, in your application's `Startup` method, configure Serilog first:
@@ -34,7 +34,7 @@ public class Startup
       .Enrich.FromLogContext()
       .WriteTo.Console()
       .CreateLogger();
-      
+
     // Other startup code
 ```
 
@@ -46,7 +46,7 @@ call `AddSerilog()` on the provided `loggingBuilder`.
   {
       services.AddLogging(loggingBuilder =>
       	loggingBuilder.AddSerilog(dispose: true));
-      
+
       // Other services ...
   }
 ```
@@ -60,7 +60,7 @@ call `AddSerilog()` on the provided `loggingBuilder`.
                         IApplicationLifetime appLifetime)
   {
       loggerfactory.AddSerilog();
-      
+
       // Ensure any buffered events are sent at shutdown
       appLifetime.ApplicationStopped.Register(Log.CloseAndFlush);
 ```
@@ -69,7 +69,7 @@ That's it! With the level bumped up a little you should see log output like:
 
 ```
 [22:14:44.646 DBG] RouteCollection.RouteAsync
-	Routes: 
+	Routes:
 		Microsoft.AspNet.Mvc.Routing.AttributeRoute
 		{controller=Home}/{action=Index}/{id?}
 	Handled? True

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ using (_logger.BeginScope(scopeProps) {
 // }
 ```
 
+### Versioning
+
+This package tracks the versioning and target framework support of its [_Microsoft.Extensions.Logging_](https://nuget.org/packages/Microsoft.Extensions.Logging) dependency.
+
 ### Credits
 
 This package evolved from an earlier package _Microsoft.Framework.Logging.Serilog_ [provided by the ASP.NET team](https://github.com/aspnet/Logging/pull/182).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,12 @@ deploy:
     secure: EN9f+XXE3fW+ebL4wxrIbafdtbNvRfddBN8UUixvctYh4qMBHzr1JdnM83QsM1zo
   skip_symbols: true
   on:
-    branch: /^(master|dev)$/
+    branch: /^(main|dev)$/
 - provider: GitHub
   auth_token:
     secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
   artifact: /Serilog.*\.nupkg/
   tag: v$(appveyor_build_version)
   on:
-    branch: master
+    branch: main
 

--- a/samples/Sample/Program.cs
+++ b/samples/Sample/Program.cs
@@ -3,75 +3,66 @@ using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Extensions.Logging;
 
-namespace Sample;
+// Creating a `LoggerProviderCollection` lets Serilog optionally write
+// events through other dynamically-added MEL ILoggerProviders.
+var providers = new LoggerProviderCollection();
 
-public class Program
+Log.Logger = new LoggerConfiguration()
+    .MinimumLevel.Debug()
+    .WriteTo.Console()
+    .WriteTo.Providers(providers)
+    .CreateLogger();
+
+var services = new ServiceCollection();
+
+services.AddSingleton(providers);
+services.AddSingleton<ILoggerFactory>(sc =>
 {
-    public static void Main(string[] args)
-    {
-        // Creating a `LoggerProviderCollection` lets Serilog optionally write
-        // events through other dynamically-added MEL ILoggerProviders.
-        var providers = new LoggerProviderCollection();
+    var providerCollection = sc.GetService<LoggerProviderCollection>();
+    var factory = new SerilogLoggerFactory(null, true, providerCollection);
 
-        Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Debug()
-            .WriteTo.Console()
-            .WriteTo.Providers(providers)
-            .CreateLogger();
+    foreach (var provider in sc.GetServices<ILoggerProvider>())
+        factory.AddProvider(provider);
 
-        var services = new ServiceCollection();
+    return factory;
+});
 
-        services.AddSingleton(providers);
-        services.AddSingleton<ILoggerFactory>(sc =>
-        {
-            var providerCollection = sc.GetService<LoggerProviderCollection>();
-            var factory = new SerilogLoggerFactory(null, true, providerCollection);
+services.AddLogging(l => l.AddConsole());
 
-            foreach (var provider in sc.GetServices<ILoggerProvider>())
-                factory.AddProvider(provider);
+var serviceProvider = services.BuildServiceProvider();
+var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
 
-            return factory;
-        });
+var startTime = DateTimeOffset.UtcNow;
+logger.LogInformation(1, "Started at {StartTime} and 0x{Hello:X} is hex of 42", startTime, 42);
 
-        services.AddLogging(l => l.AddConsole());
-
-        var serviceProvider = services.BuildServiceProvider();
-        var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
-
-        var startTime = DateTimeOffset.UtcNow;
-        logger.LogInformation(1, "Started at {StartTime} and 0x{Hello:X} is hex of 42", startTime, 42);
-
-        try
-        {
-            throw new Exception("Boom!");
-        }
-        catch (Exception ex)
-        {
-            logger.LogCritical("Unexpected critical error starting application", ex);
-            logger.Log(LogLevel.Critical, 0, "Unexpected critical error", ex, null!);
-            // This write should not log anything
-            logger.Log<object>(LogLevel.Critical, 0, null!, null, null!);
-            logger.LogError("Unexpected error", ex);
-            logger.LogWarning("Unexpected warning", ex);
-        }
-
-        using (logger.BeginScope("Main"))
-        {
-            logger.LogInformation("Waiting for user input");
-            var key = Console.Read();
-            logger.LogInformation("User pressed {@KeyInfo}", new { Key = key, KeyChar = (char)key });
-        }
-
-        var endTime = DateTimeOffset.UtcNow;
-        logger.LogInformation(2, "Stopping at {StopTime}", endTime);
-
-        logger.LogInformation("Stopping");
-
-        logger.LogInformation(Environment.NewLine);
-        logger.LogInformation("{Result,-10:l}{StartTime,15:l}{EndTime,15:l}{Duration,15:l}", "RESULT", "START TIME", "END TIME", "DURATION(ms)");
-        logger.LogInformation("{Result,-10:l}{StartTime,15:l}{EndTime,15:l}{Duration,15:l}", "------", "----- ----", "--- ----", "------------");
-        logger.LogInformation("{Result,-10:l}{StartTime,15:mm:s tt}{EndTime,15:mm:s tt}{Duration,15}", "SUCCESS", startTime, endTime, (endTime - startTime).TotalMilliseconds);
-
-        serviceProvider.Dispose();
-    }
+try
+{
+    throw new Exception("Boom!");
 }
+catch (Exception ex)
+{
+    logger.LogCritical(ex, "Unexpected critical error starting application");
+    logger.Log(LogLevel.Critical, 0, "Unexpected critical error", ex, null!);
+    // This write should not log anything
+    logger.Log<object>(LogLevel.Critical, 0, null!, null, null!);
+    logger.LogError(ex, "Unexpected error");
+    logger.LogWarning(ex, "Unexpected warning");
+}
+
+using (logger.BeginScope("Main"))
+{
+    logger.LogInformation("Waiting for user input");
+    var key = Console.Read();
+    logger.LogInformation("User pressed {@KeyInfo}", new { Key = key, KeyChar = (char)key });
+}
+
+var endTime = DateTimeOffset.UtcNow;
+logger.LogInformation(2, "Stopping at {StopTime}", endTime);
+
+logger.LogInformation("Stopping");
+
+logger.LogInformation("{Result,-10:l}{StartTime,15:l}{EndTime,15:l}{Duration,15:l}", "RESULT", "START TIME", "END TIME", "DURATION(ms)");
+logger.LogInformation("{Result,-10:l}{StartTime,15:l}{EndTime,15:l}{Duration,15:l}", "------", "----- ----", "--- ----", "------------");
+logger.LogInformation("{Result,-10:l}{StartTime,15:mm:s tt}{EndTime,15:mm:s tt}{Duration,15}", "SUCCESS", startTime, endTime, (endTime - startTime).TotalMilliseconds);
+
+serviceProvider.Dispose();

--- a/samples/Sample/Sample.csproj
+++ b/samples/Sample/Sample.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Sample</AssemblyName>
     <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/serilog-extensions-logging.sln.DotSettings
+++ b/serilog-extensions-logging.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=stringified/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/CachingMessageTemplateParser.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/CachingMessageTemplateParser.cs
@@ -38,7 +38,7 @@ class CachingMessageTemplateParser
 
         // ReSharper disable once InconsistentlySynchronizedField
         // ignored warning because this is by design
-        var result = (MessageTemplate)_templates[messageTemplate];
+        var result = (MessageTemplate?)_templates[messageTemplate];
         if (result != null)
             return result;
 

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/LevelConvert.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/LevelConvert.cs
@@ -27,9 +27,9 @@ public static class LevelConvert
     /// <summary>
     /// Convert <paramref name="logLevel"/> to the equivalent Serilog <see cref="LogEventLevel"/>.
     /// </summary>
-    /// <param name="logLevel">A Microsoft.Extensions.Logging <see cref="LogLevel"/>.</param>
+    /// <param name="logLevel">A Microsoft.Extensions.Logging <see cref="Microsoft.Extensions.Logging.LogLevel"/>.</param>
     /// <returns>The Serilog equivalent of <paramref name="logLevel"/>.</returns>
-    /// <remarks>The <see cref="LogLevel.None"/> value has no Serilog equivalent. It is mapped to
+    /// <remarks>The <see cref="Microsoft.Extensions.Logging.LogLevel.None"/> value has no Serilog equivalent. It is mapped to
     /// <see cref="LogEventLevel.Fatal"/> as the closest approximation, but this has entirely
     /// different semantics.</remarks>
     public static LogEventLevel ToSerilogLevel(LogLevel logLevel)
@@ -46,7 +46,7 @@ public static class LevelConvert
     }
 
     /// <summary>
-    /// Convert <paramref name="logEventLevel"/> to the equivalent Microsoft.Extensions.Logging <see cref="LogLevel"/>.
+    /// Convert <paramref name="logEventLevel"/> to the equivalent Microsoft.Extensions.Logging <see cref="Microsoft.Extensions.Logging.LogLevel"/>.
     /// </summary>
     /// <param name="logEventLevel">A Serilog <see cref="LogEventLevel"/>.</param>
     /// <returns>The Microsoft.Extensions.Logging equivalent of <paramref name="logEventLevel"/>.</returns>

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogValues.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogValues.cs
@@ -17,14 +17,14 @@ using System.Collections;
 
 namespace Serilog.Extensions.Logging;
 
-readonly struct SerilogLogValues : IReadOnlyList<KeyValuePair<string, object>>
+readonly struct SerilogLogValues : IReadOnlyList<KeyValuePair<string, object?>>
 {
     // Note, this struct is only used in a very limited context internally, so we ignore
     // the possibility of fields being null via the default struct initialization.
 
-    private readonly MessageTemplate _messageTemplate;
-    private readonly IReadOnlyDictionary<string, LogEventPropertyValue> _properties;
-    private readonly KeyValuePair<string, object>[] _values;
+    readonly MessageTemplate _messageTemplate;
+    readonly IReadOnlyDictionary<string, LogEventPropertyValue> _properties;
+    readonly KeyValuePair<string, object?>[] _values;
 
     public SerilogLogValues(MessageTemplate messageTemplate, IReadOnlyDictionary<string, LogEventPropertyValue> properties)
     {
@@ -34,24 +34,24 @@ readonly struct SerilogLogValues : IReadOnlyList<KeyValuePair<string, object>>
         _properties = properties ?? throw new ArgumentNullException(nameof(properties));
 
         // The array is needed because the IReadOnlyList<T> interface expects indexed access
-        _values = new KeyValuePair<string, object>[_properties.Count + 1];
+        _values = new KeyValuePair<string, object?>[_properties.Count + 1];
         var i = 0;
         foreach (var p in properties)
         {
-            _values[i] = new KeyValuePair<string, object>(p.Key, (p.Value is ScalarValue sv) ? sv.Value : p.Value);
+            _values[i] = new KeyValuePair<string, object?>(p.Key, (p.Value is ScalarValue sv) ? sv.Value : p.Value);
             ++i;
         }
-        _values[i] = new KeyValuePair<string, object>("{OriginalFormat}", _messageTemplate.Text);
+        _values[i] = new KeyValuePair<string, object?>("{OriginalFormat}", _messageTemplate.Text);
     }
 
-    public KeyValuePair<string, object> this[int index]
+    public KeyValuePair<string, object?> this[int index]
     {
         get => _values[index];
     }
 
     public int Count => _properties.Count + 1;
 
-    public IEnumerator<KeyValuePair<string, object>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, object>>)_values).GetEnumerator();
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => ((IEnumerable<KeyValuePair<string, object?>>)_values).GetEnumerator();
 
     public override string ToString() => _messageTemplate.Render(_properties);
 

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
@@ -66,7 +66,7 @@ public class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher
         List<LogEventPropertyValue>? scopeItems = null;
         for (var scope = CurrentScope; scope != null; scope = scope.Parent)
         {
-            scope.EnrichAndCreateScopeItem(logEvent, propertyFactory, out LogEventPropertyValue? scopeItem);
+            scope.EnrichAndCreateScopeItem(logEvent, propertyFactory, out var scopeItem);
 
             if (scopeItem != null)
             {
@@ -82,9 +82,9 @@ public class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher
         }
     }
 
-    readonly AsyncLocal<SerilogLoggerScope> _value = new();
+    readonly AsyncLocal<SerilogLoggerScope?> _value = new();
 
-    internal SerilogLoggerScope CurrentScope
+    internal SerilogLoggerScope? CurrentScope
     {
         get => _value.Value;
         set => _value.Value = value;

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -29,7 +27,7 @@ class SerilogLoggerScope : IDisposable
         _chainedDisposable = chainedDisposable;
     }
 
-    public SerilogLoggerScope Parent { get; }
+    public SerilogLoggerScope? Parent { get; }
 
     public void Dispose()
     {

--- a/src/Serilog.Extensions.Logging/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Extensions.Logging/Properties/AssemblyInfo.cs
@@ -1,7 +1,12 @@
-﻿using System.Reflection;
+﻿global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Threading;
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyVersion("7.0.0.0")]
 
 [assembly: InternalsVisibleTo("Serilog.Extensions.Logging.Tests, PublicKey=" +
                               "0024000004800000940000000602000000240000525341310004000001000100fb8d13fd344a1c" +

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -2,9 +2,11 @@
 
   <PropertyGroup>
     <Description>Low-level Serilog provider for Microsoft.Extensions.Logging</Description>
+    <!-- This must match the major and minor components of the referenced Microsoft.Extensions.Logging package. -->
     <VersionPrefix>7.0.0</VersionPrefix>
     <Authors>Microsoft;Serilog Contributors</Authors>
-    <!-- These must match the Dependencies tab in https://www.nuget.org/packages/microsoft.extensions.logging -->
+    <!-- These must match the Dependencies tab in https://www.nuget.org/packages/microsoft.extensions.logging at
+         the target version. -->
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>serilog;Microsoft.Extensions.Logging</PackageTags>
@@ -26,6 +28,7 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.12.0" />
+    <!-- The version of this reference must match the major and minor components of the package version prefix. -->
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -18,7 +18,6 @@
     <RepositoryType>git</RepositoryType>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ContinuousIntegrationBuild Condition="'$(APPVEYOR)' == 'true'">True</ContinuousIntegrationBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -18,8 +18,11 @@
     <RepositoryType>git</RepositoryType>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <ContinuousIntegrationBuild Condition="'$(APPVEYOR)' == 'true'">True</ContinuousIntegrationBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!-- See https://github.com/NuGet/Home/issues/6001 -->
+    <NoWarn>NU5118</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <Description>Low-level Serilog provider for Microsoft.Extensions.Logging</Description>
-    <VersionPrefix>3.1.1</VersionPrefix>
+    <VersionPrefix>7.0.0</VersionPrefix>
     <Authors>Microsoft;Serilog Contributors</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- These must match the Dependencies tab in https://www.nuget.org/packages/microsoft.extensions.logging -->
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>serilog;Microsoft.Extensions.Logging</PackageTags>
     <PackageIcon>serilog-extension-nuget.png</PackageIcon>
@@ -24,8 +25,9 @@
     <None Include="..\..\assets\serilog-extension-nuget.png" Pack="true" PackagePath="" Visible="false" />
     <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.Extensions.Logging.Benchmarks/Serilog.Extensions.Logging.Benchmarks.csproj
+++ b/test/Serilog.Extensions.Logging.Benchmarks/Serilog.Extensions.Logging.Benchmarks.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,10 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
   </ItemGroup>

--- a/test/Serilog.Extensions.Logging.Tests/Serilog.Extensions.Logging.Tests.csproj
+++ b/test/Serilog.Extensions.Logging.Tests/Serilog.Extensions.Logging.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7;net472</TargetFrameworks>
+    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,10 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />

--- a/test/Serilog.Extensions.Logging.Tests/Support/DisposeTrackingLogger.cs
+++ b/test/Serilog.Extensions.Logging.Tests/Support/DisposeTrackingLogger.cs
@@ -1,11 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
 using Serilog.Core;
 using Serilog.Events;
 
 namespace Serilog.Extensions.Logging.Tests.Support;
 
-public class DisposeTrackingLogger : ILogger, IDisposable
+sealed class DisposeTrackingLogger : ILogger, IDisposable
 {
-    public bool IsDisposed { get; set; }
+    public bool IsDisposed { get; private set; }
 
     public ILogger ForContext(ILogEventEnricher enricher)
     {
@@ -17,7 +18,7 @@ public class DisposeTrackingLogger : ILogger, IDisposable
         return new LoggerConfiguration().CreateLogger();
     }
 
-    public ILogger ForContext(string propertyName, object value, bool destructureObjects = false)
+    public ILogger ForContext(string propertyName, object? value, bool destructureObjects = false)
     {
         return new LoggerConfiguration().CreateLogger();
     }
@@ -53,29 +54,29 @@ public class DisposeTrackingLogger : ILogger, IDisposable
     {
     }
 
-    public void Write(LogEventLevel level, string messageTemplate, params object[] propertyValues)
+    public void Write(LogEventLevel level, string messageTemplate, params object?[]? propertyValues)
     {
     }
 
-    public void Write(LogEventLevel level, Exception exception, string messageTemplate)
+    public void Write(LogEventLevel level, Exception? exception, string messageTemplate)
     {
     }
 
-    public void Write<T>(LogEventLevel level, Exception exception, string messageTemplate, T propertyValue)
+    public void Write<T>(LogEventLevel level, Exception? exception, string messageTemplate, T propertyValue)
     {
     }
 
-    public void Write<T0, T1>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0,
+    public void Write<T0, T1>(LogEventLevel level, Exception? exception, string messageTemplate, T0 propertyValue0,
         T1 propertyValue1)
     {
     }
 
-    public void Write<T0, T1, T2>(LogEventLevel level, Exception exception, string messageTemplate, T0 propertyValue0,
+    public void Write<T0, T1, T2>(LogEventLevel level, Exception? exception, string messageTemplate, T0 propertyValue0,
         T1 propertyValue1, T2 propertyValue2)
     {
     }
 
-    public void Write(LogEventLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
+    public void Write(LogEventLevel level, Exception? exception, string messageTemplate, params object?[]? propertyValues)
     {
     }
 
@@ -100,28 +101,28 @@ public class DisposeTrackingLogger : ILogger, IDisposable
     {
     }
 
-    public void Verbose(string messageTemplate, params object[] propertyValues)
+    public void Verbose(string messageTemplate, params object?[]? propertyValues)
     {
     }
 
-    public void Verbose(Exception exception, string messageTemplate)
+    public void Verbose(Exception? exception, string messageTemplate)
     {
     }
 
-    public void Verbose<T>(Exception exception, string messageTemplate, T propertyValue)
+    public void Verbose<T>(Exception? exception, string messageTemplate, T propertyValue)
     {
     }
 
-    public void Verbose<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+    public void Verbose<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
     {
     }
 
-    public void Verbose<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+    public void Verbose<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
         T2 propertyValue2)
     {
     }
 
-    public void Verbose(Exception exception, string messageTemplate, params object[] propertyValues)
+    public void Verbose(Exception? exception, string messageTemplate, params object?[]? propertyValues)
     {
     }
 
@@ -141,28 +142,28 @@ public class DisposeTrackingLogger : ILogger, IDisposable
     {
     }
 
-    public void Debug(string messageTemplate, params object[] propertyValues)
+    public void Debug(string messageTemplate, params object?[]? propertyValues)
     {
     }
 
-    public void Debug(Exception exception, string messageTemplate)
+    public void Debug(Exception? exception, string messageTemplate)
     {
     }
 
-    public void Debug<T>(Exception exception, string messageTemplate, T propertyValue)
+    public void Debug<T>(Exception? exception, string messageTemplate, T propertyValue)
     {
     }
 
-    public void Debug<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+    public void Debug<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
     {
     }
 
-    public void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+    public void Debug<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
         T2 propertyValue2)
     {
     }
 
-    public void Debug(Exception exception, string messageTemplate, params object[] propertyValues)
+    public void Debug(Exception? exception, string messageTemplate, params object?[]? propertyValues)
     {
     }
 
@@ -182,28 +183,28 @@ public class DisposeTrackingLogger : ILogger, IDisposable
     {
     }
 
-    public void Information(string messageTemplate, params object[] propertyValues)
+    public void Information(string messageTemplate, params object?[]? propertyValues)
     {
     }
 
-    public void Information(Exception exception, string messageTemplate)
+    public void Information(Exception? exception, string messageTemplate)
     {
     }
 
-    public void Information<T>(Exception exception, string messageTemplate, T propertyValue)
+    public void Information<T>(Exception? exception, string messageTemplate, T propertyValue)
     {
     }
 
-    public void Information<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+    public void Information<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
     {
     }
 
-    public void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+    public void Information<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
         T2 propertyValue2)
     {
     }
 
-    public void Information(Exception exception, string messageTemplate, params object[] propertyValues)
+    public void Information(Exception? exception, string messageTemplate, params object?[]? propertyValues)
     {
     }
 
@@ -223,28 +224,28 @@ public class DisposeTrackingLogger : ILogger, IDisposable
     {
     }
 
-    public void Warning(string messageTemplate, params object[] propertyValues)
+    public void Warning(string messageTemplate, params object?[]? propertyValues)
     {
     }
 
-    public void Warning(Exception exception, string messageTemplate)
+    public void Warning(Exception? exception, string messageTemplate)
     {
     }
 
-    public void Warning<T>(Exception exception, string messageTemplate, T propertyValue)
+    public void Warning<T>(Exception? exception, string messageTemplate, T propertyValue)
     {
     }
 
-    public void Warning<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+    public void Warning<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
     {
     }
 
-    public void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+    public void Warning<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
         T2 propertyValue2)
     {
     }
 
-    public void Warning(Exception exception, string messageTemplate, params object[] propertyValues)
+    public void Warning(Exception? exception, string messageTemplate, params object?[]? propertyValues)
     {
     }
 
@@ -264,28 +265,28 @@ public class DisposeTrackingLogger : ILogger, IDisposable
     {
     }
 
-    public void Error(string messageTemplate, params object[] propertyValues)
+    public void Error(string messageTemplate, params object?[]? propertyValues)
     {
     }
 
-    public void Error(Exception exception, string messageTemplate)
+    public void Error(Exception? exception, string messageTemplate)
     {
     }
 
-    public void Error<T>(Exception exception, string messageTemplate, T propertyValue)
+    public void Error<T>(Exception? exception, string messageTemplate, T propertyValue)
     {
     }
 
-    public void Error<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+    public void Error<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
     {
     }
 
-    public void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+    public void Error<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
         T2 propertyValue2)
     {
     }
 
-    public void Error(Exception exception, string messageTemplate, params object[] propertyValues)
+    public void Error(Exception? exception, string messageTemplate, params object?[]? propertyValues)
     {
     }
 
@@ -305,40 +306,40 @@ public class DisposeTrackingLogger : ILogger, IDisposable
     {
     }
 
-    public void Fatal(string messageTemplate, params object[] propertyValues)
+    public void Fatal(string messageTemplate, params object?[]? propertyValues)
     {
     }
 
-    public void Fatal(Exception exception, string messageTemplate)
+    public void Fatal(Exception? exception, string messageTemplate)
     {
     }
 
-    public void Fatal<T>(Exception exception, string messageTemplate, T propertyValue)
+    public void Fatal<T>(Exception? exception, string messageTemplate, T propertyValue)
     {
     }
 
-    public void Fatal<T0, T1>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
+    public void Fatal<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1)
     {
     }
 
-    public void Fatal<T0, T1, T2>(Exception exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+    public void Fatal<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
         T2 propertyValue2)
     {
     }
 
-    public void Fatal(Exception exception, string messageTemplate, params object[] propertyValues)
+    public void Fatal(Exception? exception, string messageTemplate, params object?[]? propertyValues)
     {
     }
 
-    public bool BindMessageTemplate(string messageTemplate, object[] propertyValues, out MessageTemplate? parsedTemplate,
-        out IEnumerable<LogEventProperty>? boundProperties)
+    public bool BindMessageTemplate(string messageTemplate, object?[]? propertyValues, [NotNullWhen(true)] out MessageTemplate? parsedTemplate,
+        [NotNullWhen(true)] out IEnumerable<LogEventProperty>? boundProperties)
     {
         parsedTemplate = null;
         boundProperties = null;
         return false;
     }
 
-    public bool BindProperty(string propertyName, object value, bool destructureObjects, out LogEventProperty? property)
+    public bool BindProperty(string? propertyName, object? value, bool destructureObjects, [NotNullWhen(true)] out LogEventProperty? property)
     {
         property = null;
         return false;

--- a/test/Serilog.Extensions.Logging.Tests/Support/ExtensionsProvider.cs
+++ b/test/Serilog.Extensions.Logging.Tests/Support/ExtensionsProvider.cs
@@ -5,14 +5,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Serilog.Extensions.Logging.Tests.Support;
 
-public class ExtensionsProvider : ILoggerProvider, Microsoft.Extensions.Logging.ILogger
+sealed class ExtensionsProvider : ILoggerProvider, Microsoft.Extensions.Logging.ILogger
 {
-    private readonly LogLevel enabledLevel;
-    public List<(LogLevel logLevel, EventId eventId, object? state, Exception exception, string message)> Writes { get; set; } = new();
+    readonly LogLevel _enabledLevel;
+
+    public List<(LogLevel logLevel, EventId eventId, object? state, Exception? exception, string message)> Writes { get; } = new();
 
     public ExtensionsProvider(LogLevel enabledLevel)
     {
-        this.enabledLevel = enabledLevel;
+        _enabledLevel = enabledLevel;
     }
 
     public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
@@ -20,17 +21,17 @@ public class ExtensionsProvider : ILoggerProvider, Microsoft.Extensions.Logging.
         return this;
     }
 
-    public IDisposable BeginScope<TState>(TState state)
+    public IDisposable BeginScope<TState>(TState state) where TState: notnull
     {
         return this;
     }
 
     public bool IsEnabled(LogLevel logLevel)
     {
-        return enabledLevel <= logLevel;
+        return _enabledLevel <= logLevel;
     }
 
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
         Writes.Add((logLevel, eventId, state, exception, formatter(state, exception)));
     }


### PR DESCRIPTION
From v7.0.0 forwards, _Serilog.Extensions.Logging_, _Serilog.Extensions.Hosting_, and _Serilog.AspNetCore_ will all be pinned to corresponding versions of the _Microsoft.Extensions.*_ libraries that they implement. This is expected to address long-running compatibility headaches, and reduce security scanner false-positives.

Unless we have a good reason not to, this will also mean matching the TFMs supported by those libraries.

In the current case, this means that we'll add some explicit targets for TFMs that the package already covered via `netstandard2.0`.

The other changes in this PR just get the codebase building, fixing nullable reference type annotations and dealing with the usual dependency gunk. @SimonCropp some of this unfortunately overlaps with #219 - I'll sort that out post-merge :-) sorry!

**Edit:** since _Serilog.Settings.Configuration_ also tracks a _Microsoft.Extensions_ package I'm including it in this list, too.