### PR TITLE
Align framework targeting with packages

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -56,10 +56,18 @@ class SerilogLogger : FrameworkLogger
         return logLevel != LogLevel.None && _logger.IsEnabled(LevelConvert.ToSerilogLevel(logLevel));
     }
 
-    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+#if NET7_0
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
     {
         return _provider.BeginScope(state);
     }
+#else
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        return _provider.BeginScope(state);
+    }
+#endif
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -7,7 +7,7 @@
     <Authors>Microsoft;Serilog Contributors</Authors>
     <!-- These must match the Dependencies tab in https://www.nuget.org/packages/microsoft.extensions.logging at
          the target version. -->
-    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>serilog;Microsoft.Extensions.Logging</PackageTags>
     <PackageIcon>serilog-extension-nuget.png</PackageIcon>
@@ -31,8 +31,14 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <!-- The version of this reference must match the major and minor components of the package version prefix. -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Low-level Serilog provider for Microsoft.Extensions.Logging</Description>
     <!-- This must match the major and minor components of the referenced Microsoft.Extensions.Logging package. -->
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>7.1.0</VersionPrefix>
     <Authors>Microsoft;Serilog Contributors</Authors>
     <!-- These must match the Dependencies tab in https://www.nuget.org/packages/microsoft.extensions.logging at
          the target version. -->

--- a/test/Serilog.Extensions.Logging.Tests/Serilog.Extensions.Logging.Tests.csproj
+++ b/test/Serilog.Extensions.Logging.Tests/Serilog.Extensions.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net472</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net462</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/test/Serilog.Extensions.Logging.Tests/Support/ExtensionsProvider.cs
+++ b/test/Serilog.Extensions.Logging.Tests/Support/ExtensionsProvider.cs
@@ -20,11 +20,18 @@ sealed class ExtensionsProvider : ILoggerProvider, Microsoft.Extensions.Logging.
     {
         return this;
     }
-
-    public IDisposable BeginScope<TState>(TState state) where TState: notnull
+#if NET7_0
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
     {
         return this;
     }
+#else
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        return this;
+    }
+#endif
 
     public bool IsEnabled(LogLevel logLevel)
     {


### PR DESCRIPTION
Align project targets:
- removed net framework target and used netstandard2.0 as compatibility layer for all targets except .NET 6 and .NET 7
- aligned package versions as follows:
   - .net 6 and netstandard2.0 targets use v6 libraries
   - .net 7 use v7 libraries
- Fixed incompatibilities between netstandard2.0 with v6 and v7 in nullability constraints

Motivation of this change is to align framework library versions with the corresponding targets.

This is needed to be able to use library in Azure Functions (App Service) environment targeting .NET 6.0 (LTS) runtime.

And netstandard2.0 being a compatibility layer with .NET Framework, effectively targeting .NET 6.0 libraries being emitted in as build results.

This is a part 1 of cumulative change in two repositories. Second one depends on the library itself. Changes are made in a branch: https://github.com/multiarc/serilog-extensions-hosting/tree/targeting/align_framework_targeting_with_packages