### PR TITLE
add matching Microsoft.Extensions dependency requirement per target net framework

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -56,7 +56,10 @@ class SerilogLogger : FrameworkLogger
         return logLevel != LogLevel.None && _logger.IsEnabled(LevelConvert.ToSerilogLevel(logLevel));
     }
 
-    public IDisposable BeginScope<TState>(TState state) where TState : notnull
+    public IDisposable BeginScope<TState>(TState state)
+#if !NET6_0
+    where TState : notnull
+#endif
     {
         return _provider.BeginScope(state);
     }

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(targetframework)' == 'netstandard2.1' or '$(targetframework)' == 'netstandard2.0' or '$(targetframework)' == 'net462'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0-*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0-*" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -30,9 +30,19 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.12.0" />
-    <!-- The version of this reference must match the major and minor components of the package version prefix. -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(targetframework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0-*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(targetframework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0-*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(targetframework)' == 'netstandard2.1' or '$(targetframework)' == 'netstandard2.0' or '$(targetframework)' == 'net462'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0-*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Same fix as here to main branch: https://github.com/serilog/serilog-extensions-logging/pull/230 fixes: https://github.com/serilog/serilog-extensions-logging/issues/229