### PR TITLE
Support `ValueTuple<string, object?>` as state of scope.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ using (_logger.BeginScope("Transaction")) {
 If you simply want to add a "bag" of additional properties to your log events, however, this extension method approach can be overly verbose. For example, to add `TransactionId` and `ResponseJson` properties to your log events, you would have to do something like the following:
 
 ```csharp
-// WRONG! Prefer the dictionary approach below instead
+// WRONG! Prefer the dictionary or value tuple approach below instead
 using (_logger.BeginScope("TransactionId: {TransactionId}, ResponseJson: {ResponseJson}", 12345, jsonString)) {
     _logger.LogInformation("Completed in {DurationMs}ms...", 30);
 }
@@ -141,6 +141,23 @@ using (_logger.BeginScope(scopeProps) {
 //	"SourceContext":"SomeNamespace.SomeService",
 //	"TransactionId": 12345,
 //	"ResponseJson": "{ \"Key1\": \"Value1\", \"Key2\": \"Value2\" }"
+// }
+```
+
+Alternatively provide a `ValueTuple<string, object?>` to this method, where `Item1` is the property name and `Item2` is the property value. Note that `T2` _must_ be `object?`.
+
+```csharp
+using (_logger.BeginScope(("TransactionId", (object?)12345)) {
+    _logger.LogInformation("Transaction completed in {DurationMs}ms...", 30);
+}
+// Example JSON output:
+// {
+//	"@t":"2020-10-29T19:05:56.4176816Z",
+//	"@m":"Completed in 30ms...",
+//	"@i":"51812baa",
+//	"DurationMs":30,
+//	"SourceContext":"SomeNamespace.SomeService",
+//	"TransactionId": 12345
 // }
 ```
 

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggerScopeTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggerScopeTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Serilog.Events;
+using Serilog.Extensions.Logging.Tests.Support;
+
+using Xunit;
+
+namespace Serilog.Extensions.Logging.Tests;
+public class SerilogLoggerScopeTests
+{
+    static (SerilogLoggerProvider, LogEventPropertyFactory, LogEvent) SetUp()
+    {
+        var loggerProvider = new SerilogLoggerProvider();
+
+        var logEventPropertyFactory = new LogEventPropertyFactory();
+
+        var dateTimeOffset = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var messageTemplate = new MessageTemplate(Enumerable.Empty<Parsing.MessageTemplateToken>());
+        var properties = Enumerable.Empty<LogEventProperty>();
+        var logEvent = new LogEvent(dateTimeOffset, LogEventLevel.Information, null, messageTemplate, properties);
+
+        return (loggerProvider, logEventPropertyFactory, logEvent);
+    }
+
+    [Fact]
+    public void EnrichWithDictionaryStringObject()
+    {
+        const string propertyName = "Foo";
+        const string expectedValue = "Bar";
+
+        var(loggerProvider, logEventPropertyFactory, logEvent) = SetUp();
+
+
+        var state = new Dictionary<string, object?>() { { propertyName, expectedValue } };
+
+        var loggerScope = new SerilogLoggerScope(loggerProvider, state);
+
+        loggerScope.EnrichAndCreateScopeItem(logEvent, logEventPropertyFactory, out LogEventPropertyValue? scopeItem);
+
+        Assert.Contains(propertyName, logEvent.Properties);
+
+        var scalarValue = logEvent.Properties[propertyName] as ScalarValue;
+        Assert.NotNull(scalarValue);
+
+        var actualValue = scalarValue.Value as string;
+        Assert.NotNull(actualValue);
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    [Fact]
+    public void EnrichWithIEnumerableKeyValuePairStringObject()
+    {
+        const string propertyName = "Foo";
+        const string expectedValue = "Bar";
+
+        var (loggerProvider, logEventPropertyFactory, logEvent) = SetUp();
+
+
+        var state = new KeyValuePair<string, object?>[] { new KeyValuePair<string, object?>(propertyName, expectedValue) };
+
+        var loggerScope = new SerilogLoggerScope(loggerProvider, state);
+
+        loggerScope.EnrichAndCreateScopeItem(logEvent, logEventPropertyFactory, out LogEventPropertyValue? scopeItem);
+
+        Assert.Contains(propertyName, logEvent.Properties);
+
+        var scalarValue = logEvent.Properties[propertyName] as ScalarValue;
+        Assert.NotNull(scalarValue);
+
+        var actualValue = scalarValue.Value as string;
+        Assert.NotNull(actualValue);
+        Assert.Equal(expectedValue, actualValue);
+    }
+
+    [Fact]
+    public void EnrichWithTupleStringObject()
+    {
+        const string propertyName = "Foo";
+        const string expectedValue = "Bar";
+
+        var (loggerProvider, logEventPropertyFactory, logEvent) = SetUp();
+
+
+        var state = (propertyName, (object)expectedValue);
+
+        var loggerScope = new SerilogLoggerScope(loggerProvider, state);
+
+        loggerScope.EnrichAndCreateScopeItem(logEvent, logEventPropertyFactory, out LogEventPropertyValue? scopeItem);
+
+        Assert.Contains(propertyName, logEvent.Properties);
+
+        var scalarValue = logEvent.Properties[propertyName] as ScalarValue;
+        Assert.NotNull(scalarValue);
+
+        var actualValue = scalarValue.Value as string;
+        Assert.NotNull(actualValue);
+        Assert.Equal(expectedValue, actualValue);
+    }
+}

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggerScopeTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggerScopeTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright © Serilog Contributors
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Serilog.Events;

--- a/test/Serilog.Extensions.Logging.Tests/Support/LogEventPropertyFactory.cs
+++ b/test/Serilog.Extensions.Logging.Tests/Support/LogEventPropertyFactory.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright © Serilog Contributors
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Serilog.Core;

--- a/test/Serilog.Extensions.Logging.Tests/Support/LogEventPropertyFactory.cs
+++ b/test/Serilog.Extensions.Logging.Tests/Support/LogEventPropertyFactory.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Extensions.Logging.Tests.Support;
+internal class LogEventPropertyFactory : ILogEventPropertyFactory
+{
+    public LogEventProperty CreateProperty(string name, object? value, bool destructureObjects = false)
+    {
+        var scalarValue = new ScalarValue(value);
+        return new LogEventProperty(name, scalarValue);
+    }
+}


### PR DESCRIPTION
Change for issue #186.

When calling `ILogger.BeginScope<TState>(TState state)` `TState` can now be a `ValueTuple<string, object?>`, `Item1` is used as the property name and `Item2` is used as the property value.

```csharp
using (_logger.BeginScope(("TransactionId", (object?)12345)) {
    _logger.LogInformation("Transaction completed in {DurationMs}ms...", 30);
}
// Example JSON output:
// {
//	"@t":"2020-10-29T19:05:56.4176816Z",
//	"@m":"Completed in 30ms...",
//	"@i":"51812baa",
//	"DurationMs":30,
//	"SourceContext":"SomeNamespace.SomeService",
//	"TransactionId": 12345
// }
```