### PR TITLE
Optimization: used StartsWith(char) instead of StartsWith(string) where supported

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -103,12 +103,12 @@ class SerilogLogger : FrameworkLogger
                 {
                     messageTemplate = value;
                 }
-                else if (property.Key.StartsWith("@"))
+                else if (property.Key.StartsWith('@'))
                 {
                     if (_logger.BindProperty(GetKeyWithoutFirstSymbol(DestructureDictionary, property.Key), property.Value, true, out var destructured))
                         properties.Add(destructured);
                 }
-                else if (property.Key.StartsWith("$"))
+                else if (property.Key.StartsWith('$'))
                 {
                     if (_logger.BindProperty(GetKeyWithoutFirstSymbol(StringifyDictionary, property.Key), property.Value?.ToString(), true, out var stringified))
                         properties.Add(stringified);

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerScope.cs
@@ -55,12 +55,12 @@ class SerilogLoggerScope : IDisposable
         {
             var destructureObject = false;
 
-            if (key.StartsWith("@"))
+            if (key.StartsWith('@'))
             {
                 key = SerilogLogger.GetKeyWithoutFirstSymbol(SerilogLogger.DestructureDictionary, key);
                 destructureObject = true;
             }
-            else if (key.StartsWith("$"))
+            else if (key.StartsWith('$'))
             {
                 key = SerilogLogger.GetKeyWithoutFirstSymbol(SerilogLogger.StringifyDictionary, key);
                 value = value?.ToString();

--- a/src/Serilog.Extensions.Logging/Extensions/StringExtensions.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Serilog.Extensions;
+
+#if !NET6_0_OR_GREATER && !NETSTANDARD2_1_OR_GREATER
+static class StringExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool StartsWith(this string str, char value)
+    {
+        return str.Length > 0 && str[0] == value;
+    }
+}
+#endif


### PR DESCRIPTION
This PR optimizes the `SerilogLogger.PrepareWrite` method by using a `StartsWith(char)` overload instead of `StartsWith(string)` on `>= net6.0`, `>= netstandard2.0` platforms.

![image](https://github.com/user-attachments/assets/812331f0-0eb2-4ddc-a913-0b7238132305)

Big win in the benchmark from NLog project (https://github.com/NLog/NLog-Performance-tests/blob/master/MicrosofLoggingPerformance/Program.cs)

### Before

| Test Name        | Time (ms) | Msgs/sec  | GC2 | GC1 | GC0 | CPU (ms) | Alloc (MB) |
|------------------|-----------|-----------|-----|-----|-----|----------|------------|
| NLog             |     4 895 | 1 021 447 |   0 |   0 |  13 |    4 109 |    2 021,8 |
| Serilog          |    17 058 |   293 116 |   0 |   0 |  22 |   12 468 |    3 474,5 |

### After

| Test Name        | Time (ms) | Msgs/sec  | GC2 | GC1 | GC0 | CPU (ms) | Alloc (MB) |
|------------------|-----------|-----------|-----|-----|-----|----------|------------|
| NLog             |     4 753 | 1 051 935 |   0 |   0 |  13 |    4 109 |    2 021,8 |
| Serilog          |     3 443 | 1 452 118 |   0 |   0 |  22 |    3 109 |    3 514,8 |
```

