### PR TITLE
Size based EventId LogEventProperty cache

### DIFF
--- a/samples/Sample/Program.cs
+++ b/samples/Sample/Program.cs
@@ -32,16 +32,37 @@ services.AddLogging(l => l.AddConsole());
 var serviceProvider = services.BuildServiceProvider();
 var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
 
-var eventId = new EventId(1001, "Test");
+var startTime = DateTimeOffset.UtcNow;
+logger.LogInformation(1, "Started at {StartTime} and 0x{Hello:X} is hex of 42", startTime, 42);
 
-for (int i = 0; i < 1_000; i++)
+try
 {
-    logger.Log(
-        LogLevel.Information,
-        eventId,
-        "Subscription {SubscriptionId} for entity {EntityName} handler for message {MessageId} has been successfully completed.",
-        "my-subscription-id",
-        "TestQueue",
-        1);
+    throw new Exception("Boom!");
 }
+catch (Exception ex)
+{
+    logger.LogCritical(ex, "Unexpected critical error starting application");
+    logger.Log(LogLevel.Critical, 0, "Unexpected critical error", ex, null!);
+    // This write should not log anything
+    logger.Log<object>(LogLevel.Critical, 0, null!, null, null!);
+    logger.LogError(ex, "Unexpected error");
+    logger.LogWarning(ex, "Unexpected warning");
+}
+
+using (logger.BeginScope("Main"))
+{
+    logger.LogInformation("Waiting for user input");
+    var key = Console.Read();
+    logger.LogInformation("User pressed {@KeyInfo}", new { Key = key, KeyChar = (char)key });
+}
+
+var endTime = DateTimeOffset.UtcNow;
+logger.LogInformation(2, "Stopping at {StopTime}", endTime);
+
+logger.LogInformation("Stopping");
+
+logger.LogInformation("{Result,-10:l}{StartTime,15:l}{EndTime,15:l}{Duration,15:l}", "RESULT", "START TIME", "END TIME", "DURATION(ms)");
+logger.LogInformation("{Result,-10:l}{StartTime,15:l}{EndTime,15:l}{Duration,15:l}", "------", "----- ----", "--- ----", "------------");
+logger.LogInformation("{Result,-10:l}{StartTime,15:mm:s tt}{EndTime,15:mm:s tt}{Duration,15}", "SUCCESS", startTime, endTime, (endTime - startTime).TotalMilliseconds);
+
 serviceProvider.Dispose();

--- a/samples/Sample/Program.cs
+++ b/samples/Sample/Program.cs
@@ -32,37 +32,16 @@ services.AddLogging(l => l.AddConsole());
 var serviceProvider = services.BuildServiceProvider();
 var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
 
-var startTime = DateTimeOffset.UtcNow;
-logger.LogInformation(1, "Started at {StartTime} and 0x{Hello:X} is hex of 42", startTime, 42);
+var eventId = new EventId(1001, "Test");
 
-try
+for (int i = 0; i < 1_000; i++)
 {
-    throw new Exception("Boom!");
+    logger.Log(
+        LogLevel.Information,
+        eventId,
+        "Subscription {SubscriptionId} for entity {EntityName} handler for message {MessageId} has been successfully completed.",
+        "my-subscription-id",
+        "TestQueue",
+        1);
 }
-catch (Exception ex)
-{
-    logger.LogCritical(ex, "Unexpected critical error starting application");
-    logger.Log(LogLevel.Critical, 0, "Unexpected critical error", ex, null!);
-    // This write should not log anything
-    logger.Log<object>(LogLevel.Critical, 0, null!, null, null!);
-    logger.LogError(ex, "Unexpected error");
-    logger.LogWarning(ex, "Unexpected warning");
-}
-
-using (logger.BeginScope("Main"))
-{
-    logger.LogInformation("Waiting for user input");
-    var key = Console.Read();
-    logger.LogInformation("User pressed {@KeyInfo}", new { Key = key, KeyChar = (char)key });
-}
-
-var endTime = DateTimeOffset.UtcNow;
-logger.LogInformation(2, "Stopping at {StopTime}", endTime);
-
-logger.LogInformation("Stopping");
-
-logger.LogInformation("{Result,-10:l}{StartTime,15:l}{EndTime,15:l}{Duration,15:l}", "RESULT", "START TIME", "END TIME", "DURATION(ms)");
-logger.LogInformation("{Result,-10:l}{StartTime,15:l}{EndTime,15:l}{Duration,15:l}", "------", "----- ----", "--- ----", "------------");
-logger.LogInformation("{Result,-10:l}{StartTime,15:mm:s tt}{EndTime,15:mm:s tt}{Duration,15}", "SUCCESS", startTime, endTime, (endTime - startTime).TotalMilliseconds);
-
 serviceProvider.Dispose();

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/EventIdPropertyCache.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/EventIdPropertyCache.cs
@@ -10,63 +10,94 @@ namespace Serilog.Extensions.Logging
     {
         private readonly object _createLock = new();
         private readonly int _maxCapacity;
-        private readonly Dictionary<int, LogEventProperty> _propertyCache;
+        private readonly Dictionary<EventKey, LogEventProperty> _propertyCache;
 
         private int count;
 
         public EventIdPropertyCache(int maxCapacity)
         {
-            this._maxCapacity = maxCapacity;
-            this._propertyCache = new Dictionary<int, LogEventProperty>(capacity: maxCapacity);
+            _maxCapacity = maxCapacity;
+            _propertyCache = new Dictionary<EventKey, LogEventProperty>(capacity: maxCapacity);
         }
 
         public LogEventProperty GetOrCreateProperty(in EventId eventId)
         {
-            if (_propertyCache.TryGetValue(eventId.Id, out var cachedProperty))
+            var eventKey = new EventKey(eventId);
+
+            if (_propertyCache.TryGetValue(eventKey, out var cachedProperty))
             {
                 return cachedProperty;
             }
 
             lock (_createLock)
             {
-                return GetOrCreateSynchronized(in eventId);
+                // Double check under lock
+                if (_propertyCache.TryGetValue(eventKey, out cachedProperty))
+                {
+                    return cachedProperty;
+                }
+
+                cachedProperty = CreateCore(in eventKey);
+
+                if (count < _maxCapacity)
+                {
+                    _propertyCache[eventKey] = cachedProperty;
+                    count++;
+                }
+
+                return cachedProperty;
             }
         }
 
-        private static LogEventProperty CreateCore(in EventId eventId)
+        private static LogEventProperty CreateCore(in EventKey eventKey)
         {
             var properties = new List<LogEventProperty>(2);
 
-            if (eventId.Id != 0)
+            if (eventKey.Id != 0)
             {
-                properties.Add(new LogEventProperty("Id", new ScalarValue(eventId.Id)));
+                properties.Add(new LogEventProperty("Id", new ScalarValue(eventKey.Id)));
             }
 
-            if (eventId.Name != null)
+            if (eventKey.Name != null)
             {
-                properties.Add(new LogEventProperty("Name", new ScalarValue(eventId.Name)));
+                properties.Add(new LogEventProperty("Name", new ScalarValue(eventKey.Name)));
             }
 
             return new LogEventProperty("EventId", new StructureValue(properties));
         }
 
-        private LogEventProperty GetOrCreateSynchronized(in EventId eventId)
+        private readonly struct EventKey : IEquatable<EventKey>
         {
-            // Double check under lock
-            if (_propertyCache.TryGetValue(eventId.Id, out var cachedProperty))
-            {
-                return cachedProperty;
-            }
-
-            cachedProperty = CreateCore(in eventId);
-
-            if (count < _maxCapacity)
-            {
-                _propertyCache[eventId.Id] = cachedProperty;
-                count++;
-            }
             
-            return cachedProperty;
+            public EventKey(EventId eventId)
+            {
+                Id = eventId.Id;
+                Name = eventId.Name;
+            }
+
+            public int Id { get; }
+
+            public string? Name { get; }
+
+            /// <inheritdoc />
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = 17;
+
+                    hashCode = (hashCode * 397) ^ this.Id;
+                    hashCode = (hashCode * 397) ^ (this.Name?.GetHashCode() ?? 0);
+
+                    return hashCode;
+                }
+            }
+
+            /// <inheritdoc />
+            public bool Equals(EventKey other) => this.Id == other.Id && this.Name == other.Name;
+
+            /// <inheritdoc />
+            public override bool Equals(object? obj) => obj is EventKey other && Equals(other);
         }
     }
 }

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/EventIdPropertyCache.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/EventIdPropertyCache.cs
@@ -1,0 +1,72 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Serilog.Extensions.Logging
+{
+    using Microsoft.Extensions.Logging;
+    using Serilog.Events;
+
+    internal sealed class EventIdPropertyCache
+    {
+        private readonly object _createLock = new();
+        private readonly int _maxCapacity;
+        private readonly Dictionary<int, LogEventProperty> _propertyCache;
+
+        private int count;
+
+        public EventIdPropertyCache(int maxCapacity)
+        {
+            this._maxCapacity = maxCapacity;
+            this._propertyCache = new Dictionary<int, LogEventProperty>(capacity: maxCapacity);
+        }
+
+        public LogEventProperty GetOrCreateProperty(in EventId eventId)
+        {
+            if (_propertyCache.TryGetValue(eventId.Id, out var cachedProperty))
+            {
+                return cachedProperty;
+            }
+
+            lock (_createLock)
+            {
+                return GetOrCreateSynchronized(in eventId);
+            }
+        }
+
+        private static LogEventProperty CreateCore(in EventId eventId)
+        {
+            var properties = new List<LogEventProperty>(2);
+
+            if (eventId.Id != 0)
+            {
+                properties.Add(new LogEventProperty("Id", new ScalarValue(eventId.Id)));
+            }
+
+            if (eventId.Name != null)
+            {
+                properties.Add(new LogEventProperty("Name", new ScalarValue(eventId.Name)));
+            }
+
+            return new LogEventProperty("EventId", new StructureValue(properties));
+        }
+
+        private LogEventProperty GetOrCreateSynchronized(in EventId eventId)
+        {
+            // Double check under lock
+            if (_propertyCache.TryGetValue(eventId.Id, out var cachedProperty))
+            {
+                return cachedProperty;
+            }
+
+            cachedProperty = CreateCore(in eventId);
+
+            if (count < _maxCapacity)
+            {
+                _propertyCache[eventId.Id] = cachedProperty;
+                count++;
+            }
+            
+            return cachedProperty;
+        }
+    }
+}

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/EventIdPropertyCache.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/EventIdPropertyCache.cs
@@ -66,7 +66,7 @@ namespace Serilog.Extensions.Logging
             return new LogEventProperty("EventId", new StructureValue(properties));
         }
 
-        private readonly struct EventKey : IEquatable<EventKey>
+        private readonly record struct EventKey
         {
             
             public EventKey(EventId eventId)
@@ -78,26 +78,6 @@ namespace Serilog.Extensions.Logging
             public int Id { get; }
 
             public string? Name { get; }
-
-            /// <inheritdoc />
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    var hashCode = 17;
-
-                    hashCode = (hashCode * 397) ^ this.Id;
-                    hashCode = (hashCode * 397) ^ (this.Name?.GetHashCode() ?? 0);
-
-                    return hashCode;
-                }
-            }
-
-            /// <inheritdoc />
-            public bool Equals(EventKey other) => this.Id == other.Id && this.Name == other.Name;
-
-            /// <inheritdoc />
-            public override bool Equals(object? obj) => obj is EventKey other && Equals(other);
         }
     }
 }

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/EventIdPropertyCache.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/EventIdPropertyCache.cs
@@ -1,5 +1,16 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 namespace Serilog.Extensions.Logging
 {

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -29,9 +29,6 @@ class SerilogLogger : FrameworkLogger
     readonly SerilogLoggerProvider _provider;
     readonly ILogger _logger;
 
-    /// Per-ILogger LogEventProperty cache for EventId.
-    /// Each ILogger has its own cache.
-    /// Each { ILogger, EventId.Id } pair is assumed to be unique.
     readonly EventIdPropertyCache _eventPropertyCache = new (48);
 
     static readonly CachingMessageTemplateParser MessageTemplateParser = new();

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -28,8 +28,9 @@ class SerilogLogger : FrameworkLogger
 
     readonly SerilogLoggerProvider _provider;
     readonly ILogger _logger;
+    readonly EventIdPropertyCache _eventIdPropertyCache = new();
 
-    static readonly CachingMessageTemplateParser MessageTemplateParser = new ();
+    static readonly CachingMessageTemplateParser MessageTemplateParser = new();
 
     public SerilogLogger(
         SerilogLoggerProvider provider,
@@ -150,7 +151,7 @@ class SerilogLogger : FrameworkLogger
         }
 
         if (eventId.Id != 0 || eventId.Name != null)
-            properties.Add(EventIdPropertyCache.GetOrCreateProperty(in eventId));
+            properties.Add(_eventIdPropertyCache.GetOrCreateProperty(in eventId));
 
         var (traceId, spanId) = Activity.Current is { } activity ?
             (activity.TraceId, activity.SpanId) :

--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -29,9 +29,7 @@ class SerilogLogger : FrameworkLogger
     readonly SerilogLoggerProvider _provider;
     readonly ILogger _logger;
 
-    readonly EventIdPropertyCache _eventPropertyCache = new (48);
-
-    static readonly CachingMessageTemplateParser MessageTemplateParser = new();
+    static readonly CachingMessageTemplateParser MessageTemplateParser = new ();
 
     public SerilogLogger(
         SerilogLoggerProvider provider,
@@ -152,7 +150,7 @@ class SerilogLogger : FrameworkLogger
         }
 
         if (eventId.Id != 0 || eventId.Name != null)
-            properties.Add(this._eventPropertyCache.GetOrCreateProperty(in eventId));
+            properties.Add(EventIdPropertyCache.GetOrCreateProperty(in eventId));
 
         var (traceId, spanId) = Activity.Current is { } activity ?
             (activity.TraceId, activity.SpanId) :

--- a/test/Serilog.Extensions.Logging.Benchmarks/LogEventBenchmark.cs
+++ b/test/Serilog.Extensions.Logging.Benchmarks/LogEventBenchmark.cs
@@ -34,6 +34,7 @@ namespace Serilog.Extensions.Logging.Benchmarks
 
         readonly IMelLogger _melLogger;
         readonly Person _bob, _alice;
+        readonly EventId _eventId = new EventId(1, "Test");
 
         public LogEventBenchmark()
         {
@@ -60,6 +61,17 @@ namespace Serilog.Extensions.Logging.Benchmarks
         {
             using (var scope = _melLogger.BeginScope("Hi {@User} from {$Me}", _bob, _alice))
                 _melLogger.LogInformation("Hi");
+        }
+
+        [Benchmark]
+        public void LogInformation_WithEventId()
+        {
+            this._melLogger.Log(
+                LogLevel.Information,
+                _eventId,
+                "Hi {@User} from {$Me}",
+                _bob,
+                _alice);
         }
     }
 }

--- a/test/Serilog.Extensions.Logging.Tests/EventIdPropertyCacheTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/EventIdPropertyCacheTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+using Serilog.Events;
+using Xunit;
+
+namespace Serilog.Extensions.Logging.Tests
+{
+    public class EventIdPropertyCacheTests
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(48)]
+        [InlineData(100)]
+        public void LowAndHighNumberedEventIdsAreMapped(int id)
+        {
+            // Arrange
+            var cache = new EventIdPropertyCache(48);
+
+            var eventId = new EventId(id, "test");
+
+            // Act
+            var mapped = cache.GetOrCreateProperty(eventId);
+
+            // Assert
+            var value = Assert.IsType<StructureValue>(mapped.Value);
+            Assert.Equal(2, value.Properties.Count);
+
+            var idValue = value.Properties.Single(p => p.Name == "Id").Value;
+            var scalar = Assert.IsType<ScalarValue>(idValue);
+            Assert.Equal(id, scalar.Value);
+        }
+    }
+}

--- a/test/Serilog.Extensions.Logging.Tests/EventIdPropertyCacheTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/EventIdPropertyCacheTests.cs
@@ -28,12 +28,10 @@ namespace Serilog.Extensions.Logging.Tests
         public void LowAndHighNumberedEventIdsAreMapped(int id)
         {
             // Arrange
-            var cache = new EventIdPropertyCache(48);
-
             var eventId = new EventId(id, "test");
 
             // Act
-            var mapped = cache.GetOrCreateProperty(eventId);
+            var mapped = EventIdPropertyCache.GetOrCreateProperty(eventId);
 
             // Assert
             var value = Assert.IsType<StructureValue>(mapped.Value);

--- a/test/Serilog.Extensions.Logging.Tests/EventIdPropertyCacheTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/EventIdPropertyCacheTests.cs
@@ -1,5 +1,16 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Copyright (c) Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 using Microsoft.Extensions.Logging;
 using Serilog.Events;

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
@@ -517,22 +517,6 @@ public class SerilogLoggerTest
         }
     }
 
-    [Theory]
-    [InlineData(1)]
-    [InlineData(10)]
-    [InlineData(48)]
-    [InlineData(100)]
-    public void LowAndHighNumberedEventIdsAreMapped(int id)
-    {
-        var orig = new EventId(id, "test");
-        var mapped = SerilogLogger.CreateEventIdProperty(orig);
-        var value = Assert.IsType<StructureValue>(mapped.Value);
-        Assert.Equal(2, value.Properties.Count);
-        var idValue = value.Properties.Single(p => p.Name == "Id").Value;
-        var scalar = Assert.IsType<ScalarValue>(idValue);
-        Assert.Equal(id, scalar.Value);
-    }
-
     [Fact]
     public void MismatchedMessageTemplateParameterCountIsHandled()
     {


### PR DESCRIPTION
Address #259 

The `LogEventConstructionBenchmark` results

BenchmarkDotNet v0.13.10, Windows 10 (10.0.19045.5073/22H2/2022Update)
Intel Core i5-10300H CPU 2.50GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 8.0.10 (8.0.1024.46610), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.10 (8.0.1024.46610), X64 RyuJIT AVX2

Before:
| Method       | Mean     | Error   | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------- |---------:|--------:|---------:|------:|--------:|-------:|----------:|------------:|
| Native       | 207.0 ns | 4.18 ns |  4.29 ns |  1.00 |    0.00 | 0.0706 |     296 B |        1.00 |
| NoId         | 296.4 ns | 3.47 ns |  3.07 ns |  1.43 |    0.04 | 0.1106 |     464 B |        1.57 |
| LowNumbered  | 381.9 ns | 5.28 ns |  4.68 ns |  1.84 |    0.05 | 0.1740 |     728 B |        2.46 |
| HighNumbered | 394.6 ns | 7.43 ns | 13.76 ns |  1.97 |    0.06 | 0.1931 |     808 B |        2.73 |

After:
| Method       | Mean     | Error   | StdDev  | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|------------- |---------:|--------:|--------:|------:|--------:|-------:|----------:|------------:|
| Native       | 209.7 ns | 4.00 ns | 3.75 ns |  1.00 |    0.00 | 0.0706 |     296 B |        1.00 |
| NoId         | 296.4 ns | 5.75 ns | 5.10 ns |  1.41 |    0.04 | 0.1106 |     464 B |        1.57 |
| LowNumbered  | 348.0 ns | 6.91 ns | 6.47 ns |  1.66 |    0.04 | 0.1335 |     560 B |        1.89 |
| HighNumbered | 332.4 ns | 3.61 ns | 3.20 ns |  1.59 |    0.03 | 0.1335 |     560 B |        1.89 |
