### PR TITLE
Async disposal on .NET 6 or later

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLoggerProvider.cs
@@ -15,7 +15,7 @@ namespace Serilog.Extensions.Logging;
 /// </summary>
 [ProviderAlias("Serilog")]
 public class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher, ISupportExternalScope
-#if NET6_0_OR_GREATER
+#if FEATURE_ASYNCDISPOSABLE
     , IAsyncDisposable
 #endif
 {
@@ -25,7 +25,7 @@ public class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher, ISuppor
     // May be null; if it is, Log.Logger will be lazily used
     readonly ILogger? _logger;
     readonly Action? _dispose;
-#if NET6_0_OR_GREATER
+#if FEATURE_ASYNCDISPOSABLE
     readonly Func<ValueTask>? _disposeAsync;
 #endif
     private IExternalScopeProvider? _externalScopeProvider;
@@ -45,7 +45,7 @@ public class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher, ISuppor
             if (logger != null)
             {
                 _dispose = () => (logger as IDisposable)?.Dispose();
-#if NET6_0_OR_GREATER
+#if FEATURE_ASYNCDISPOSABLE
                 _disposeAsync = () =>
                 {
                     // Dispose via IAsyncDisposable if possible, otherwise fall back to IDisposable
@@ -58,7 +58,7 @@ public class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher, ISuppor
             else
             {
                 _dispose = Log.CloseAndFlush;
-#if NET6_0_OR_GREATER
+#if FEATURE_ASYNCDISPOSABLE
                 _disposeAsync = Log.CloseAndFlushAsync;
 #endif
             }
@@ -137,7 +137,7 @@ public class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher, ISuppor
         _dispose?.Invoke();
     }
 
-#if NET6_0_OR_GREATER
+#if FEATURE_ASYNCDISPOSABLE
     /// <inheritdoc />
     public ValueTask DisposeAsync()
     {

--- a/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
+++ b/src/Serilog.Extensions.Logging/Serilog.Extensions.Logging.csproj
@@ -36,18 +36,18 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-    <DefineConstants>$(DefineConstants);FEATURE_ITUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ITUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <DefineConstants>$(DefineConstants);FEATURE_ITUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ITUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <DefineConstants>$(DefineConstants);FEATURE_ITUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ITUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <DefineConstants>$(DefineConstants);FEATURE_ITUPLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_ITUPLE;FEATURE_ASYNCDISPOSABLE</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/test/Serilog.Extensions.Logging.Tests/DisposeTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/DisposeTests.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog.Core;
+using Serilog.Events;
+using Xunit;
+
+namespace Serilog.Extensions.Logging.Tests;
+
+public class DisposeTests
+{
+    private readonly DisposableSink _sink;
+    private readonly Logger _serilogLogger;
+
+    public DisposeTests()
+    {
+        _sink = new DisposableSink();
+        _serilogLogger = new LoggerConfiguration()
+            .WriteTo.Sink(_sink)
+            .CreateLogger();
+    }
+
+    [Fact]
+    public void AddSerilog_must_dispose_the_provider_when_dispose_is_true()
+    {
+        var services = new ServiceCollection()
+            .AddLogging(builder => builder.AddSerilog(logger: _serilogLogger, dispose: true))
+            .BuildServiceProvider();
+
+        // Get a logger so that we ensure SerilogLoggerProvider is created
+        var logger = services.GetRequiredService<ILogger<DisposeTests>>();
+        logger.LogInformation("Hello, world!");
+
+        services.Dispose();
+        Assert.True(_sink.DisposeCalled);
+        Assert.False(_sink.DisposeAsyncCalled);
+    }
+
+#if NET8_0_OR_GREATER
+    [Fact]
+    public async Task AddSerilog_must_async_dispose_the_provider_when_dispose_is_true()
+    {
+      var services = new ServiceCollection()
+            .AddLogging(builder => builder.AddSerilog(logger: _serilogLogger, dispose: true))
+            .BuildServiceProvider();
+
+        // Get a logger so that we ensure SerilogLoggerProvider is created
+        var logger = services.GetRequiredService<ILogger<DisposeTests>>();
+        logger.LogInformation("Hello, world!");
+
+        await services.DisposeAsync();
+        Assert.False(_sink.DisposeCalled);
+        Assert.True(_sink.DisposeAsyncCalled);
+    }
+#endif
+
+    private sealed class DisposableSink : ILogEventSink, IDisposable, IAsyncDisposable
+    {
+        public bool DisposeAsyncCalled { get; private set; }
+        public bool DisposeCalled { get; private set; }
+
+        public void Dispose() => DisposeCalled = true;
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncCalled = true;
+            return default;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+        }
+    }
+}

--- a/test/Serilog.Extensions.Logging.Tests/DisposeTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/DisposeTests.cs
@@ -20,7 +20,7 @@ public class DisposeTests
     }
 
     [Fact]
-    public void AddSerilog_must_dispose_the_provider_when_dispose_is_true()
+    public void DisposesProviderWhenDisposeIsTrue()
     {
         var services = new ServiceCollection()
             .AddLogging(builder => builder.AddSerilog(logger: _serilogLogger, dispose: true))
@@ -37,7 +37,7 @@ public class DisposeTests
 
 #if NET8_0_OR_GREATER
     [Fact]
-    public async Task AddSerilog_must_async_dispose_the_provider_when_dispose_is_true()
+    public async Task DisposesProviderAsyncWhenDisposeIsTrue()
     {
       var services = new ServiceCollection()
             .AddLogging(builder => builder.AddSerilog(logger: _serilogLogger, dispose: true))

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggingBuilderExtensionsTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggingBuilderExtensionsTests.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Serilog.Extensions.Logging.Tests.Support;
+using Xunit;
+
+namespace Serilog.Extensions.Logging.Tests;
+
+public class SerilogLoggingBuilderExtensionsTests
+{
+    [Fact]
+    public void AddSerilog_must_register_a_ILoggerProvider()
+    {
+        var services = new ServiceCollection()
+            .AddLogging(builder => { builder.AddSerilog(); })
+            .BuildServiceProvider();
+
+        var loggerProviders = services.GetServices<ILoggerProvider>();
+        Assert.Contains(loggerProviders, provider => provider is SerilogLoggerProvider);
+    }
+
+    [Fact]
+    public void AddSerilog_must_register_a_ILoggerProvider_that_forwards_logs_to_static_Serilog_Logger()
+    {
+        var sink = new SerilogSink();
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        var services = new ServiceCollection()
+            .AddLogging(builder => { builder.AddSerilog(); })
+            .BuildServiceProvider();
+
+        var logger = services.GetRequiredService<ILogger<SerilogLoggingBuilderExtensionsTests>>();
+        logger.LogInformation("Hello, world!");
+
+        Assert.Single(sink.Writes);
+    }
+
+    [Fact]
+    public void AddSerilog_must_register_a_ILoggerProvider_that_forwards_logs_to_provided_logger()
+    {
+        var sink = new SerilogSink();
+        var serilogLogger = new LoggerConfiguration()
+            .WriteTo.Sink(sink)
+            .CreateLogger();
+
+        var services = new ServiceCollection()
+            .AddLogging(builder => { builder.AddSerilog(logger: serilogLogger); })
+            .BuildServiceProvider();
+
+        var logger = services.GetRequiredService<ILogger<SerilogLoggingBuilderExtensionsTests>>();
+        logger.LogInformation("Hello, world!");
+
+        Assert.Single(sink.Writes);
+    }
+}

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggingBuilderExtensionsTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggingBuilderExtensionsTests.cs
@@ -8,7 +8,7 @@ namespace Serilog.Extensions.Logging.Tests;
 public class SerilogLoggingBuilderExtensionsTests
 {
     [Fact]
-    public void AddSerilog_must_register_a_ILoggerProvider()
+    public void AddSerilogMustRegisterAnILoggerProvider()
     {
         var services = new ServiceCollection()
             .AddLogging(builder => { builder.AddSerilog(); })
@@ -19,7 +19,7 @@ public class SerilogLoggingBuilderExtensionsTests
     }
 
     [Fact]
-    public void AddSerilog_must_register_a_ILoggerProvider_that_forwards_logs_to_static_Serilog_Logger()
+    public void AddSerilogMustRegisterAnILoggerProviderThatForwardsLogsToStaticSerilogLogger()
     {
         var sink = new SerilogSink();
         Log.Logger = new LoggerConfiguration()
@@ -37,7 +37,7 @@ public class SerilogLoggingBuilderExtensionsTests
     }
 
     [Fact]
-    public void AddSerilog_must_register_a_ILoggerProvider_that_forwards_logs_to_provided_logger()
+    public void AddSerilogMustRegisterAnILoggerProviderThatForwardsLogsToProvidedLogger()
     {
         var sink = new SerilogSink();
         var serilogLogger = new LoggerConfiguration()


### PR DESCRIPTION
Currently `SerilogLoggerProvider` only implements `IDisposable` which means that sinks that implement `IAsyncDisposable` will not be disposed async when `dispose=true` is passed to `AddSerilog()`.

In this PR I have opt'ed to only implement `IAsyncDisposable` for .NET 6 or later as we can't use the static `Log.CloseAndFlushAsync()` method on .NET Framework. When an existing `ILogger` is provided to `AddSerilog()` and `dispose=true` we will now try to call `IAsyncDisposable.DisposeAsync()` and fallback to `IDisposable.Dispose()`.
If no existing `ILogger` is provided we will use `Log.CloseAndFlushAsync()` for async disposal.

The PR also includes tests of the disposal functionality, as well as some more high level "functional" tests of the functionality implemented in `AddSerilog()`, mainly forwarding of logs from `MS..Extensions.ILogger<T>` to Serilog sink.

This change is related to a similar change I made in App Insights sink, see https://github.com/serilog-contrib/serilog-sinks-applicationinsights/pull/228. 
