### PR TITLE
When an event id is specified, and a property named EventId exists in the template, the intrinsic event id wins

### DIFF
--- a/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
+++ b/src/Serilog.Extensions.Logging/Extensions/Logging/SerilogLogger.cs
@@ -40,7 +40,7 @@ sealed class SerilogLogger : FrameworkLogger
         _provider = provider ?? throw new ArgumentNullException(nameof(provider));
 
         // If a logger was passed, the provider has already added itself as an enricher
-        _logger = logger ?? Serilog.Log.Logger.ForContext(new[] { provider });
+        _logger = logger ?? Serilog.Log.Logger.ForContext([provider]);
 
         if (name != null)
         {
@@ -91,7 +91,7 @@ sealed class SerilogLogger : FrameworkLogger
 
         var properties = new Dictionary<string, LogEventPropertyValue>();
 
-        if (state is IEnumerable<KeyValuePair<string, object>> structure)
+        if (state is IEnumerable<KeyValuePair<string, object?>> structure)
         {
             foreach (var property in structure)
             {
@@ -155,7 +155,7 @@ sealed class SerilogLogger : FrameworkLogger
 
         // The overridden `!=` operator on this type ignores `Name`.
         if (eventId.Id != 0 || eventId.Name != null)
-            properties.Add("EventId", _eventIdPropertyCache.GetOrCreatePropertyValue(in eventId));
+            properties["EventId"] = _eventIdPropertyCache.GetOrCreatePropertyValue(in eventId);
 
         var (traceId, spanId) = Activity.Current is { } activity ?
             (activity.TraceId, activity.SpanId) :

--- a/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
+++ b/test/Serilog.Extensions.Logging.Tests/SerilogLoggerTests.cs
@@ -618,4 +618,20 @@ public class SerilogLoggerTest
         var scalar = Assert.IsType<ScalarValue>(result);
         Assert.Equal(expectedValue, scalar.Value);
     }
+
+    [Fact]
+    public void ConflictingEventIdTemplatePropertyIsIgnored()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        var loggedEventId = 17;
+        logger.LogInformation(loggedEventId, "{EventId}", 42);
+
+        var write = Assert.Single(sink.Writes);
+        var recordedEventIdProperty = Assert.IsType<StructureValue>(write.Properties["EventId"]);
+        var recordedEventIdStructure = Assert.Single(recordedEventIdProperty.Properties, p => p.Name == "Id");
+        var recordedEventIdPropertyValue = Assert.IsType<ScalarValue>(recordedEventIdStructure.Value);
+        var recordedEventId = Assert.IsType<int>(recordedEventIdPropertyValue.Value);
+        Assert.Equal(loggedEventId, recordedEventId);
+    }
 }


### PR DESCRIPTION
Fixes #273